### PR TITLE
sorting keys alphabetically

### DIFF
--- a/src/devtools/components/ComponentInspector.vue
+++ b/src/devtools/components/ComponentInspector.vue
@@ -22,7 +22,7 @@
         </span>
       </section>
       <section class="data">
-        <data-field v-for="field in target.state"
+        <data-field v-for="field in sortedState"
           track-by="key"
           :field="field"
           :depth="0">
@@ -48,6 +48,9 @@ export default {
   computed: {
     hasTarget () {
       return this.target.id != null
+    },
+    sortedState() {
+      return this.target.state && this.target.state.slice().sort((a, b) => a.key > b.key)
     }
   },
   methods: {

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -22,7 +22,7 @@
     </div>
     <div class="children" v-if="expanded && isExpandableType">
       <data-field
-        v-for="subField in formattedSubFields | limitBy limit"
+        v-for="subField in limitedSubFields"
         track-by="$index"
         :field="subField"
         :depth="depth + 1">
@@ -108,8 +108,12 @@ export default {
           key,
           value: value[key]
         }))
+        value = value.slice().sort((a, b) => a.key > b.key)
       }
       return value
+    },
+    limitedSubFields () {
+      return this.formattedSubFields.slice(0, this.limit)
     }
   },
   methods: {

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -21,8 +21,9 @@ module.exports = {
       // select child instance
       .click('.instance .instance:nth-child(1) .self')
       .assert.containsText('.component-name', 'Counter')
-      .assert.containsText('.data-field', 'test: 1 computed')
-      .assert.containsText('.data-field:nth-child(2)', 'count: 0 vuex getter')
+      .assert.containsText('.data-field', 'count: 0 vuex getter')
+      .assert.containsText('.data-field:nth-child(2)', 'hello: undefined')
+      .assert.containsText('.data-field:nth-child(3)', 'test: 1 computed')
 
       // expand child instance
       .click('.instance .instance:nth-child(2) .arrow-wrapper')


### PR DESCRIPTION
ref #107 

Now keys in inspector are displayed alphabetically, additionally I removed `limitBy` so it should work with Vue 2.0 