### PR TITLE
Fix sorting of component properties in component inspector

### DIFF
--- a/src/devtools/components/ComponentInspector.vue
+++ b/src/devtools/components/ComponentInspector.vue
@@ -50,7 +50,11 @@ export default {
       return this.target.id != null
     },
     sortedState () {
-      return this.target.state && this.target.state.slice().sort((a, b) => a.key > b.key)
+      return this.target.state && this.target.state.slice().sort((a, b) => {
+        if(a.key < b.key) return -1
+        if(a.key > b.key) return 1
+        return 0
+      })
     }
   },
   methods: {


### PR DESCRIPTION
The component properties within the component inspector are not always sorted in the correct alphabetical order. An example of this can be found in the TransitionGroup component in the "HackerNews Clone Example" from the docs:

![unsorted_properties](https://cloud.githubusercontent.com/assets/3519464/18924910/2c93921a-85b2-11e6-8b4e-64ed8b7b46e2.png)

This pr fixes the sorting of the properties. 
