### PR TITLE
Update conf for webpack 2.1.0-beta.25

### DIFF
--- a/shells/chrome/webpack.config.js
+++ b/shells/chrome/webpack.config.js
@@ -20,7 +20,16 @@ module.exports = {
     }
   },
   module: {
-    loaders: [
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue',
+        options: {
+          loaders: {
+            js: 'buble'
+          }
+        }
+      },
       {
         test: /\.js$/,
         loader:  'buble',
@@ -35,11 +44,6 @@ module.exports = {
         loader: 'url?limit=0'
       }
     ]
-  },
-  vue: {
-    loaders: {
-      js: 'buble'
-    }
   },
   devtool: process.env.NODE_ENV !== 'production'
     ? '#inline-source-map'

--- a/shells/dev/webpack.config.js
+++ b/shells/dev/webpack.config.js
@@ -18,26 +18,26 @@ module.exports = {
     }
   },
   module: {
-    loaders: [
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue',
+        options: {
+          loaders: {
+            js: 'buble'
+          }
+        }
+      },
       {
         test: /\.js$/,
         loader:  'buble',
         exclude: /node_modules|vue\/dist|vuex\/dist/,
       },
       {
-        test: /\.vue$/,
-        loader: 'vue'
-      },
-      {
         test: /\.(png|woff2)$/,
         loader: 'url?limit=0'
       }
     ]
-  },
-  vue: {
-    loaders: {
-      js: 'buble'
-    }
   },
   devtool: '#source-map'
 }


### PR DESCRIPTION
Moving vue-loader options to module.rules since webpack 2 no longer allows custom properties in configuration