### PR TITLE
Avoid using document.all

### DIFF
--- a/shells/chrome/src/detector.js
+++ b/shells/chrome/src/detector.js
@@ -6,7 +6,8 @@ window.addEventListener('message', e => {
 
 function detect (win) {
   setTimeout(() => {
-    const el = [].find.call(document.all, e => e.__vue__)
+    const all = document.querySelectorAll('*')
+    const el = [].find.call(all, e => e.__vue__)
     if (el) {
       let Vue = el.__vue__.constructor
       while (Vue.super) {


### PR DESCRIPTION
`document.all` returns an `HTMLAllCollection` which has some, uhm, [special](http://stackoverflow.com/questions/10350142/why-is-document-all-falsy), behavior. This is causing errors when es6-shim is present, which in some cases overwrites the native `Array.prototype.find` with its own implementation.

This is an attempt to prevent vue-devtools from throwing an error in Chrome when es6-shim is present.

See: https://github.com/paulmillr/es6-shim/issues/428