### PR TITLE
Remove currently broken re-emit events feature in events history pane

### DIFF
--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -1,10 +1,6 @@
 import { stringify } from '../util'
 
-export function initEventsBackend (vue, bridge, instanceMap, getInstanceName) {
-  bridge.on('trigger-event', (event) => {
-    const instance = instanceMap.get(event.instanceId)
-    instance._events[event.eventName][0](event.eventData)
-  })
+export function initEventsBackend (vue, bridge, getInstanceName) {
   const vueEmit = vue.prototype.$emit
   vue.prototype.$emit = function () {
     vueEmit.apply(this, arguments)

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -32,7 +32,7 @@ export function initBackend (_bridge) {
       initVuexBackend(hook, bridge)
     })
   }
-  initEventsBackend(hook.Vue, bridge, instanceMap, getInstanceName)
+  initEventsBackend(hook.Vue, bridge, getInstanceName)
 }
 
 function connect () {

--- a/src/devtools/components/EventsHistory.vue
+++ b/src/devtools/components/EventsHistory.vue
@@ -32,12 +32,6 @@
         <div class="event-meta">
           <span class="time">
             <div>{{ event.timestamp | formatTime }}</div>
-            <div v-if="activeEventIndex === index" class="action-wrapper">
-              <a class="action" @click.stop="emitSelected(event)">
-                <i class="material-icons">flare</i>
-                <span>Emit</span>
-              </a>
-            </span>
           </span>
         </div>
       </div>
@@ -71,9 +65,6 @@ export default {
     },
     reset () {
       this.$store.commit('events/RESET')
-    },
-    emitSelected (event) {
-      bridge.send('trigger-event', event)
     },
     filterEvents () {
       this.$store.commit('events/FILTER_EVENTS', this.filter)


### PR DESCRIPTION
Currently the re-emit events feature in the events history pane is broken. We can't re-emit events on conditionally rendered components anyways (the component for the event may be removed).