### PR TITLE
fix [].find error

### DIFF
--- a/shells/chrome/src/detector.js
+++ b/shells/chrome/src/detector.js
@@ -7,7 +7,7 @@ window.addEventListener('message', e => {
 function detect (win) {
   setTimeout(() => {
     const all = document.querySelectorAll('*')
-    const el = [].find.call(all, e => e.__vue__)
+    const el = [].filter.call(all, e => !!e.__vue__)[0]
     if (el) {
       let Vue = el.__vue__.constructor
       while (Vue.super) {


### PR DESCRIPTION
Chrome (`version: 44.0.2403.125`) does not support  `[].find`, so change to `[].filter`.