### PR TITLE
Change attached and detached lifecycle hooks in key-nav mixin

### DIFF
--- a/src/devtools/mixins/key-nav.js
+++ b/src/devtools/mixins/key-nav.js
@@ -18,10 +18,10 @@ document.addEventListener('keyup', e => {
 })
 
 export default {
-  attached () {
+  mounted () {
     activeInstances.push(this)
   },
-  detached () {
+  destroyed () {
     const i = activeInstances.indexOf(this)
     if (i >= 0) {
       activeInstances.splice(i, 1)


### PR DESCRIPTION
Changed for mounted and destroyed respectively to fix not working arrow keys navigation.