### PR TITLE
flush Vuex history on reload

### DIFF
--- a/src/devtools/store/modules/vuex/index.js
+++ b/src/devtools/store/modules/vuex/index.js
@@ -15,6 +15,7 @@ const mutations = {
   'vuex/INIT' (state, initialState) {
     state.initial = state.base = initialState
     state.hasVuex = true
+    reset(state)
   },
   'vuex/RECEIVE_MUTATION' (state, entry) {
     state.history.push(entry)


### PR DESCRIPTION
Just added call to `reset` on `vuex/INIT` mutation. Fixes #174 