### PR TITLE
Added eslint-plugin-html as it's required for the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "css-loader": "^0.25.0",
     "eslint": "^3.9.1",
     "eslint-config-vue": "^2.0.0",
+    "eslint-plugin-html": "^1.7.0",
     "eslint-plugin-vue": "^1.0.0",
     "file-loader": "^0.9.0",
     "nightwatch": "^0.9.4",


### PR DESCRIPTION
eslint-plugin-html is required for a successful build, but was not included in the package.json.