### PR TITLE
Fix couple of issues on the events tab after refactor for named slots and namespaced vuex modules

### DIFF
--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -151,7 +151,7 @@ export default {
   overflow hidden
   flex 1
 
-$event-count-bubble-size = 22px
+$event-count-bubble-size = 17px
 
 .event-count
   background-color $active-color
@@ -161,8 +161,8 @@ $event-count-bubble-size = 22px
   height $event-count-bubble-size
   text-align center
   line-height $event-count-bubble-size
-  font-size $event-count-bubble-size * 0.5
+  font-size $event-count-bubble-size * 0.55
   position absolute
   right 0
-  top 3px
+  top 8px
 </style>

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -68,7 +68,7 @@ function initApp (shell) {
 
     bridge.on('event:emit', payload => {
       store.commit('events/EMIT', parse(payload))
-      if (store.state.app.tab !== 'events') {
+      if (store.state.tab !== 'events') {
         store.commit('events/INCREASE_NEW_EVENT_COUNT')
       }
     })

--- a/src/devtools/views/events/EventInspector.vue
+++ b/src/devtools/views/events/EventInspector.vue
@@ -8,7 +8,7 @@
     <div v-if="!hasEventData" slot="scroll" class="notice">
       <div>No event data available</div>
     </div>
-    <div v-if="hasEventData">
+    <div v-if="hasEventData" slot="scroll">
       <div class="data-fields">
         <data-field
           v-if="isComplex"


### PR DESCRIPTION
Fixes the following issues on the events tab:

- After the refactor for namespaced vuex modules by @yyx990803 , there was a wrong access of the store in src/devtools/index.js (store.state.app.tab instead of store.state.tab).

- After the refactor for named slots by @yyx990803 , the div for the event data had a missing slot attribute (therefore the event data was not shown).

- Minor styling clean up of the event count bubble.