### PR TITLE
Fix broadcasting events with Vue 1.x (fixes #220)

### DIFF
--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -13,7 +13,10 @@ export function initEventsBackend (Vue, bridge) {
     const res = vueEmit.apply(this, arguments)
 
     if (recording) {
-      const eventName = arguments[0]
+      let eventName = String(arguments[0])
+      if (Object.prototype.toString.call(arguments[0]) === '[object Object]' && arguments[0].name) {
+        eventName = String(arguments[0].name)
+      }
       if (!eventName.startsWith('hook:')) {
         bridge.send('event:emit', stringify({
           instanceId: this._uid,


### PR DESCRIPTION
This pull request tries to fix #220. 

@yyx990803 : If events get broadcastet in Vue 1.x, the arguments on the Vue.$emit function are slightly different (first argument is object instead of string), right? With this pull request I try to compensate for that.



