### PR TITLE
make z-index bigger

### DIFF
--- a/src/backend/highlighter.js
+++ b/src/backend/highlighter.js
@@ -3,7 +3,7 @@ import { inDoc } from '../util'
 const overlay = document.createElement('div')
 overlay.style.backgroundColor = 'rgba(104, 182, 255, 0.35)'
 overlay.style.position = 'fixed'
-overlay.style.zIndex = '99999'
+overlay.style.zIndex = '99999999999999'
 overlay.style.pointerEvents = 'none'
 
 /**


### PR DESCRIPTION
I'm often having components rendered inside nested modals which have big `z-index`-es. It is very inconvenient for me to not be able to quickly hover over an component inside vue-devtools and not get a nice-looking hightlight (it is just hidden behind my modals). This pull request fixes that, probably in a dumb way.