### PR TITLE
Fix recognition of Vue root elements if they are in the Shadow DOM

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -123,7 +123,18 @@ function scan () {
 
 function walk (node, fn) {
   if (node.childNodes) {
-    Array.prototype.forEach.call(node.childNodes, function (node) {
+    node.childNodes.forEach(function (node) {
+      const stop = fn(node)
+      if (!stop) {
+        walk(node, fn)
+      }
+    })
+  }
+
+  // This code is duplicated because there doesn't seem to be
+  // a reasonable way to concat NodeLists
+  if (node.shadowRoot && node.shadowRoot.childNodes) {
+    node.shadowRoot.childNodes.forEach(function (node) {
       const stop = fn(node)
       if (!stop) {
         walk(node, fn)


### PR DESCRIPTION
At the moment, the Vue DevTools will not recognize any Vue root elements if they are in a Shadow DOM.

This is what my DOM tree looks like:
![image](https://cloud.githubusercontent.com/assets/2098462/21825153/d9251dc4-d782-11e6-8dd6-cb137c97d0be.png)

The DevTools don't show anything
![image](https://cloud.githubusercontent.com/assets/2098462/21825177/f8e8237c-d782-11e6-9573-a891122c8d7b.png)

This is because the [`walk` function](https://github.com/vuejs/vue-devtools/blob/master/src/backend/index.js#L124-L133) only traverses `.childNodes`, but not `.shadowRoot.childNodes`.

I added the necessary code to traverse the `.shadowRoot`, and it works fine for me, now.

I also changed the Loop from `Array.prototype.forEach.call` to `node.childNodes.forEach`, because [`NodeList` supports `.forEach()`](https://developer.mozilla.org/de/docs/Web/API/NodeList), and it also works fine.

I didn't find a good/reasonable way to concat the two NodeLists before iterating (`.concat()` isn't available on `NodeList`s), so I duplicated the code, for now.