### PR TITLE
List getters in Vuex tab

### DIFF
--- a/shells/dev/target/Counter.vue
+++ b/shells/dev/target/Counter.vue
@@ -3,6 +3,8 @@
     <p>{{ count }}</p>
     <button class="increment" @click="increment">+1</button>
     <button class="decrement" @click="decrement">-1</button>
+
+    <p>Your counter is {{$store.getters.isPositive ? 'positive' : 'negative'}}</p>
   </div>
 </template>
 

--- a/shells/dev/target/Counter.vue
+++ b/shells/dev/target/Counter.vue
@@ -4,7 +4,7 @@
     <button class="increment" @click="increment">+1</button>
     <button class="decrement" @click="decrement">-1</button>
 
-    <p>Your counter is {{$store.getters.isPositive ? 'positive' : 'negative'}}</p>
+    <p>Your counter is {{ $store.getters.isPositive ? 'positive' : 'negative' }}</p>
   </div>
 </template>
 

--- a/shells/dev/target/store.js
+++ b/shells/dev/target/store.js
@@ -10,5 +10,8 @@ export default new Vuex.Store({
   mutations: {
     INCREMENT: state => state.count++,
     DECREMENT: state => state.count--
+  },
+  getters: {
+    isPositive: state => state.count >= 0
   }
 })

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -3,7 +3,7 @@ import { stringify, parse } from '../util'
 export function initVuexBackend (hook, bridge) {
   const store = hook.store
   let recording = true
-  bridge.send('vuex:init', stringify(store.state))
+  bridge.send('vuex:init', stringify({state: store.state, getters: store.getters}))
 
   // deal with multiple backend injections
   hook.off('vuex:mutation')
@@ -17,7 +17,7 @@ export function initVuexBackend (hook, bridge) {
         payload: stringify(mutation.payload)
       },
       timestamp: Date.now(),
-      state: stringify(state)
+      state: stringify({state, getters: store.getters}),
     })
   })
 

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -33,7 +33,7 @@ export function initVuexBackend (hook, bridge) {
   bridge.on('vuex:import-state', state => {
     hook.emit('vuex:travel-to-state', parse(state, true /* revive */))
     bridge.send('vuex:init', {
-      state: state,
+      state,
       getters: stringify(store.getters)
     })
   })

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -68,8 +68,8 @@ function initApp (shell) {
       store.commit('components/RECEIVE_INSTANCE_DETAILS', parse(details))
     })
 
-    bridge.on('vuex:init', state => {
-      store.commit('vuex/INIT', state)
+    bridge.on('vuex:init', payload => {
+      store.commit('vuex/INIT', payload)
     })
 
     bridge.on('vuex:mutation', payload => {

--- a/src/devtools/views/vuex/VuexStateInspector.vue
+++ b/src/devtools/views/vuex/VuexStateInspector.vue
@@ -75,7 +75,7 @@ export default {
   },
   methods: {
     copyStateToClipboard () {
-      copyToClipboard({state: this.inspectedState.state, getters: this.inspectedState.getters})
+      copyToClipboard(this.inspectedState.state)
       this.showStateCopiedMessage = true
       window.setTimeout(() => {
         this.showStateCopiedMessage = false
@@ -98,7 +98,7 @@ export default {
       } else {
         try {
           parse(importedStr) // Try to parse
-          this.$store.dispatch('vuex/importState', importedStr)
+          bridge.send('vuex:import-state', importedStr)
           this.showBadJSONMessage = false
         } catch (e) {
           this.showBadJSONMessage = true

--- a/src/devtools/views/vuex/VuexStateInspector.vue
+++ b/src/devtools/views/vuex/VuexStateInspector.vue
@@ -75,7 +75,7 @@ export default {
   },
   methods: {
     copyStateToClipboard () {
-      copyToClipboard(this.inspectedState.state)
+      copyToClipboard({state: this.inspectedState.state, getters: this.inspectedState.getters})
       this.showStateCopiedMessage = true
       window.setTimeout(() => {
         this.showStateCopiedMessage = false

--- a/src/devtools/views/vuex/actions.js
+++ b/src/devtools/views/vuex/actions.js
@@ -1,5 +1,3 @@
-import {parse, stringify} from '../../../util'
-
 export function commitAll ({ commit, state }) {
   if (state.history.length > 0) {
     commit('COMMIT_ALL')
@@ -48,22 +46,14 @@ export function toggleRecording ({ state, commit }) {
   bridge.send('vuex:toggle-recording', state.enabled)
 }
 
-export function importState ({ commit }, importedState) {
-  commit('INIT', importedState)
-  let parsedState = parse(importedState)
-  bridge.send('vuex:travel-to-state', stringify(parsedState.state))
-}
-
 export function updateFilter ({ commit }, filter) {
   commit('UPDATE_FILTER', filter)
 }
 
 function travelTo (state, commit, index) {
   const { history, base } = state
-  const targetState = index > -1 ? history[index].state : base
+  const targetState = index > -1 ? history[index].state : base.state
 
-  // Need to send only the state (not getters) into the bridge
-  let parsedState = parse(targetState)
-  bridge.send('vuex:travel-to-state', stringify(parsedState.state))
+  bridge.send('vuex:travel-to-state', targetState)
   commit('TIME_TRAVEL', index)
 }

--- a/src/devtools/views/vuex/actions.js
+++ b/src/devtools/views/vuex/actions.js
@@ -1,3 +1,5 @@
+import {parse, stringify} from '../../../util'
+
 export function commitAll ({ commit, state }) {
   if (state.history.length > 0) {
     commit('COMMIT_ALL')
@@ -46,9 +48,8 @@ export function toggleRecording ({ state, commit }) {
   bridge.send('vuex:toggle-recording', state.enabled)
 }
 
-export function importState ({ commit, dispatch }, importedState) {
+export function importState ({ commit }, importedState) {
   commit('INIT', importedState)
-  dispatch('reset')
 }
 
 export function updateFilter ({ commit }, filter) {
@@ -58,6 +59,9 @@ export function updateFilter ({ commit }, filter) {
 function travelTo (state, commit, index) {
   const { history, base } = state
   const targetState = index > -1 ? history[index].state : base
-  bridge.send('vuex:travel-to-state', targetState)
+
+  // Need to send only the state (not getters) into the bridge
+  let parsedState = parse(targetState)
+  bridge.send('vuex:travel-to-state', stringify(parsedState.state))
   commit('TIME_TRAVEL', index)
 }

--- a/src/devtools/views/vuex/actions.js
+++ b/src/devtools/views/vuex/actions.js
@@ -50,6 +50,8 @@ export function toggleRecording ({ state, commit }) {
 
 export function importState ({ commit }, importedState) {
   commit('INIT', importedState)
+  let parsedState = parse(importedState)
+  bridge.send('vuex:travel-to-state', stringify(parsedState.state))
 }
 
 export function updateFilter ({ commit }, filter) {

--- a/src/devtools/views/vuex/module.js
+++ b/src/devtools/views/vuex/module.js
@@ -100,8 +100,8 @@ const getters = {
         res.payload = parse(entry.mutation.payload)
       }
     }
-    res.state = parse(entry ? entry.state : base)
-    return res
+
+    return parse(entry ? entry.state : base)
   },
 
   filteredHistory ({ history, filterRegex }) {

--- a/src/devtools/views/vuex/module.js
+++ b/src/devtools/views/vuex/module.js
@@ -23,8 +23,8 @@ const state = {
 }
 
 const mutations = {
-  'INIT' (state, initialState) {
-    state.initial = state.base = initialState
+  'INIT' (state, initial) {
+    state.initial = state.base = {state: initial.state, getters: initial.getters}
     state.hasVuex = true
     reset(state)
   },
@@ -35,7 +35,10 @@ const mutations = {
     }
   },
   'COMMIT_ALL' (state) {
-    state.base = state.history[state.history.length - 1].state
+    state.base = {
+      state: state.history[state.history.length - 1].state,
+      getters: state.history[state.history.length - 1].getters
+    }
     state.lastCommit = Date.now()
     reset(state)
   },
@@ -43,7 +46,10 @@ const mutations = {
     reset(state)
   },
   'COMMIT' (state, index) {
-    state.base = state.history[index].state
+    state.base = {
+      state: state.history[index].state,
+      getters: state.history[index].getters
+    }
     state.lastCommit = Date.now()
     state.history = state.history.slice(index + 1)
     state.inspectedIndex = -1
@@ -101,7 +107,9 @@ const getters = {
       }
     }
 
-    return parse(entry ? entry.state : base)
+    res.state = parse(entry ? entry.state : base.state)
+    res.getters = parse(entry ? entry.getters : base.getters)
+    return res
   },
 
   filteredHistory ({ history, filterRegex }) {

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -150,6 +150,16 @@ module.exports = {
         .assert.containsText('#counter p', '2')
         .frame(null)
 
+      // getters
+      .assert.containsText('.vuex-state-inspector', 'isPositive:true')
+      .frame('target')
+        .click('.decrement')
+        .click('.decrement')
+        .click('.decrement')
+        .frame(null)
+      .click('.history .entry:nth-child(4)')
+      .assert.containsText('.vuex-state-inspector', 'isPositive:false')
+
       // toggle recording
       .click('.toggle-recording')
       .assert.containsText('.toggle-recording', 'Paused')
@@ -158,7 +168,7 @@ module.exports = {
       .frame('target')
         .click('.increment')
         .frame(null)
-      .assert.count('.history .entry', 1)
+      .assert.count('.history .entry', 4)
 
       // copy vuex state
       .click('.export')


### PR DESCRIPTION
Hello,

This PR allows to list all getters defined in the application, just next to the state.

![gif0k0igsv](https://cloud.githubusercontent.com/assets/6941117/22996409/f0bfb580-f3ce-11e6-9e1b-782b70f01bdf.gif)

I have a huge application with complex getters, because my state needs to be manipulate (flatten, transformed, ...). Sometimes, it's very difficult to guess the result of the getter according to the state.
In the dev exemple I added a simple getter `isPositive` that returns `true` if `count` is upper or equal than zero.

**Implementation**:
* The action `vuex/importState` doesn't exist anymore. When the user import a state, I send an event through the bridge in order to get updated getters. The bridge will send back the `vuex:init` event to initialize the state and getters ([here](https://github.com/vuejs/vue-devtools/compare/master...AnthonySendra:master#diff-465ca035d2cf1cbe2006f96f847ee38fR33)).
* ^ This also fix a bug: the UI was not updated when the state was imported.
* In the internal store, `base` and `initial ` have now `state` and `getters` as attributes
* On each mutations, the new value of getters is send ([here](https://github.com/vuejs/vue-devtools/compare/master...AnthonySendra:master#diff-465ca035d2cf1cbe2006f96f847ee38fR15))