### PR TITLE
respect Vue.config.devtools

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -109,7 +109,12 @@ function scan () {
         inFragment = true
         currentFragment = instance
       }
-      rootInstances.push(instance)
+
+      // respect Vue.config.devtools option
+      if (instance.$options._base.config.devtools) {
+        rootInstances.push(instance)
+      }
+
       return true
     }
   })


### PR DESCRIPTION
Following up on https://github.com/vuejs/vue/issues/4957 with a bit more concrete reproduction and with a fix for it.

Okay, I've got a reproduction for that thing in a separated repo: [CLICK ME](https://github.com/andreiglingeanu/vue-devtools-bug-reproduction).

It has two problems:

1. repeated `_uid`, which is easily fixable by replacing `uid++` with something like `Math.floor(Math.random() * 100) + 1 + uid`, [here](https://github.com/vuejs/vue/blob/dev/src/core/instance/init.js#L16). See the gif in the reproduction repo
2. `vue-devtools` are accepting Vue instances which had their `Vue.config.devtools` set to false.

This pull request goes about fixing only the second concern, because the first one has to be fixed from the `vuejs/vue` repo.
