### PR TITLE
Fix components names on Windows

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -5,6 +5,16 @@ import { highlight, unHighlight, getInstanceRect } from './highlighter'
 import { initVuexBackend } from './vuex'
 import { initEventsBackend } from './events'
 import { stringify, classify, camelize } from '../util'
+import path from 'path'
+
+// Use a custom basename functions instead of the shimed version
+// because it doesn't work on Windows
+function basename (filename, ext) {
+  return path.basename(
+    filename.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/'),
+    ext
+  )
+}
 
 // hook should have been injected before this executes.
 const hook = window.__VUE_DEVTOOLS_GLOBAL_HOOK__
@@ -317,7 +327,7 @@ export function getInstanceName (instance) {
   }
   const file = instance.$options.__file // injected by vue-loader
   if (file) {
-    return classify(require('path').basename(file).replace(/\.vue$/, ''))
+    return classify(basename(file, '.vue'))
   }
   return instance.$root === instance
     ? 'Root'


### PR DESCRIPTION
Fix #256 

I ended up doing the manual (ugly) fix because I couldn't find a basename/path package that worked on windows...
