### PR TITLE
Toggle component tree recursively with alt key pressed

### DIFF
--- a/src/devtools/views/components/ComponentInstance.vue
+++ b/src/devtools/views/components/ComponentInstance.vue
@@ -14,7 +14,7 @@
         <!-- arrow wrapper for better hit box -->
         <span class="arrow-wrapper"
           v-if="instance.children.length"
-          @click.stop="toggle()">
+          @click.stop="toggle">
           <span class="arrow right" :class="{ rotated: expanded }">
           </span>
         </span>
@@ -71,8 +71,8 @@ export default {
     }
   },
   methods: {
-    toggle () {
-      this.toggleWithValue(!this.expanded)
+    toggle (event) {
+      this.toggleWithValue(!this.expanded, event.altKey)
     },
     expand () {
       this.toggleWithValue(true)
@@ -80,10 +80,11 @@ export default {
     collapse () {
       this.toggleWithValue(false)
     },
-    toggleWithValue (val) {
-      this.$store.commit('components/TOGGLE_INSTANCE', {
-        id: this.instance.id,
-        expanded: val
+    toggleWithValue (val, recursive = false) {
+      this.$store.dispatch('components/toggleInstance', {
+        instance: this.instance,
+        expanded: val,
+        recursive
       })
     },
     select () {

--- a/src/devtools/views/components/module.js
+++ b/src/devtools/views/components/module.js
@@ -30,8 +30,25 @@ const mutations = {
   }
 }
 
+const actions = {
+  toggleInstance ({commit, dispatch}, {instance, expanded, recursive}) {
+    commit('TOGGLE_INSTANCE', {id: instance.id, expanded})
+
+    if (recursive) {
+      instance.children.forEach((child) => {
+        dispatch('toggleInstance', {
+          instance: child,
+          expanded,
+          recursive
+        })
+      })
+    }
+  }
+}
+
 export default {
   namespaced: true,
   state,
-  mutations
+  mutations,
+  actions
 }


### PR DESCRIPTION
Once application grows, it becomes irritating to have to click component by component to expand the tree. Following Chrome's convention (as pointed by @kaleb) I added support for toggling the tree recursively if 'alt' key is pressed during toggle. 

I also think it's high time for 'Settings' tab to be able to customize Devtool's behaviour. E.g. for example I'd like to start with component tree fully expanded but I guess I'll just submit Feature request