### PR TITLE
change enumeration method of component's computed props

### DIFF
--- a/shells/dev/target/Other.vue
+++ b/shells/dev/target/Other.vue
@@ -6,8 +6,19 @@
 </template>
 
 <script>
+// this computed property should be visible 
+// even if component has no 'computed' defined
+const computedPropMixin = {
+  computed: {
+    computedPropFromMixin() {
+      return null
+    }
+  }
+}
+
 export default {
   props: ['id'],
+  mixins: [ computedPropMixin ],
   data () {
     let a = { c: function () {} }
     a.a = a

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -429,23 +429,33 @@ function processState (instance) {
  */
 
 function processComputed (instance) {
-  return Object.keys(instance.$options.computed || {}).map(key => {
+  const computed = []
+  // use for...in here because if 'computed' is not defined
+  // on component, computed properties will be placed in prototype
+  // and Object.keys does not include
+  // properties from object's prototype
+  for (const key in (instance.$options.computed || {})) {
     // use try ... catch here because some computed properties may
     // throw error during its evaluation
+    let computedProp = null
     try {
-      return {
+      computedProp = {
         type: 'computed',
         key,
         value: instance[key]
       }
     } catch (e) {
-      return {
+      computedProp = {
         type: 'computed',
         key,
         value: '(error during evaluation)'
       }
     }
-  })
+
+    computed.push(computedProp)
+  }
+
+  return computed
 }
 
 /**


### PR DESCRIPTION
Fixes #271. `Object.keys` does not include properties from prototype chain and when `computed` is not defined on the component, all of the computed properties come from the prototype.