### PR TITLE
Support Classes as types in props

### DIFF
--- a/shells/dev/target/MyClass.js
+++ b/shells/dev/target/MyClass.js
@@ -1,0 +1,5 @@
+export default class MyClass {
+  constructor () {
+    this.msg = 'hi'
+  }
+}

--- a/shells/dev/target/Target.vue
+++ b/shells/dev/target/Target.vue
@@ -10,11 +10,13 @@
 
 <script>
 import Other from './Other.vue'
+import MyClass from './MyClass.js'
 export default {
   components: { Other },
   props: {
     msg: String,
-    obj: null
+    obj: null,
+    ins: MyClass
   },
   data() {
     return {

--- a/shells/dev/target/index.js
+++ b/shells/dev/target/index.js
@@ -4,6 +4,7 @@ import Target from './Target.vue'
 import Other from './Other.vue'
 import Counter from './Counter.vue'
 import Events from './Events.vue'
+import MyClass from './MyClass.js'
 
 let items = []
 for (var i = 0; i < 100; i++) {
@@ -18,7 +19,7 @@ new Vue({
   render (h) {
     return h('div', null, [
       h(Counter),
-      h(Target, {props:{msg:'hi'}}),
+      h(Target, {props:{msg: 'hi', ins: new MyClass()}}),
       h(Other),
       h(Events)
     ])

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -387,10 +387,11 @@ function processProps (instance) {
  * @param {Function} fn
  */
 
-const fnTypeRE = /^function (\w+)\(/
+const fnTypeRE = /^(?:function|class) (\w+)/
 function getPropType (type) {
+  const match = type.toString().match(fnTypeRE)
   return typeof type === 'function'
-    ? type.toString().match(fnTypeRE)[1]
+    ? match && match[1] || 'any'
     : 'any'
 }
 

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -24,6 +24,13 @@ module.exports = {
       // should expand root by default
       .assert.count('.instance', baseInstanceCount)
 
+      // prop types
+      .click('.instance .instance:nth-child(2) .self')
+      .assert.containsText('.component-name', 'Target')
+      .assert.containsText('.data-field:nth-child(5)', 'msg:"hi"')
+      .assert.containsText('.data-field:nth-child(6)', 'obj:undefined')
+      .assert.containsText('.data-field:nth-child(2)', 'ins:Object')
+
       // select child instance
       .click('.instance .instance:nth-child(1) .self')
       .assert.containsText('.component-name', 'Counter')


### PR DESCRIPTION
Fix #273
Also returns any instead of throwing an error if the regex doesn't match
anything.