### PR TITLE
fix instance id clashes with multiple roots on a page

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -60,9 +60,7 @@ function connect () {
 
   bridge.on('select-instance', id => {
     currentInspectedId = id
-    console.log(id)
     const instance = instanceMap.get(id)
-    console.log(instance)
     if (instance) {
       scrollIntoView(instance)
       highlight(instance)

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -28,6 +28,7 @@ let bridge
 let filter = ''
 let captureCount = 0
 let isLegacy = false
+let rootUID = 0
 
 export function initBackend (_bridge) {
   bridge = _bridge
@@ -128,7 +129,9 @@ function scan () {
       if (baseVue.config && baseVue.config.devtools) {
         // give a unique id to root instance so we can
         // 'namespace' its children
-        instance.__VUE_DEVTOOLS_ROOT_UID__ = rootInstances.length
+        if (typeof instance.__VUE_DEVTOOLS_ROOT_UID__ === 'undefined') {
+          instance.__VUE_DEVTOOLS_ROOT_UID__ = ++rootUID
+        }
         rootInstances.push(instance)
       }
 


### PR DESCRIPTION
Closes #289.

Allows for multiple roots using different `Vue` instances (e.g. 1 from webpack bundle, other loaded from CDN) without 'selecting' 2 instances when clicking on an instance in component tree.