### PR TITLE
display regExp string representation in instance inspector

### DIFF
--- a/shells/dev/target/Other.vue
+++ b/shells/dev/target/Other.vue
@@ -43,6 +43,7 @@ export default {
           f: true,
           g: 12345,
           h: 'I am a really long string mostly just to see how the horizontal scrolling works.',
+          i: new RegExp('12345', 'ig'),
         }
       }
     }

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -38,6 +38,7 @@
 import { UNDEFINED, INFINITY, isPlainObject } from 'src/util'
 
 const rawTypeRE = /^\[object (\w+)]$/
+const regExpRE = /^(\/.*?\/\w*)/
 
 export default {
   name: 'DataField',
@@ -83,14 +84,16 @@ export default {
       } else if (isPlainObject(value)) {
         return 'Object' + (Object.keys(value).length ? '' : ' (empty)')
       } else if (typeof value === 'string') {
+        var regexMatch = value.match(regExpRE)
         var typeMatch = value.match(rawTypeRE)
+        if (regexMatch) {
+          return regexMatch[1]
+        }
         if (typeMatch) {
           return typeMatch[1]
         } else {
           return JSON.stringify(value)
         }
-      } else if (value instanceof RegExp) {
-        return value.toString()
       } else {
         return value
       }

--- a/src/util.js
+++ b/src/util.js
@@ -78,7 +78,9 @@ function reviver (key, val) {
  */
 
 function sanitize (data) {
-  if (
+  if (isRegExp(data)) {
+    return RegExp.prototype.toString.call(data)
+  } else if (
     !isPrimitive(data) &&
     !Array.isArray(data) &&
     !isPlainObject(data)
@@ -103,9 +105,12 @@ function isPrimitive (data) {
   return (
     type === 'string' ||
     type === 'number' ||
-    type === 'boolean' ||
-    data instanceof RegExp
+    type === 'boolean'
   )
+}
+
+function isRegExp (data) {
+  return data instanceof RegExp
 }
 
 export function searchDeepInObject (obj, searchTerm) {


### PR DESCRIPTION
Closes #276.

Unfortunately this is a bit hacky, because stringifying RegExp loses information about actual expression inside, so I called `.toString()` in `sanitize` method.