### PR TITLE
Fix ComponentInstance.vue to be sorted properly

### DIFF
--- a/src/devtools/views/components/ComponentInstance.vue
+++ b/src/devtools/views/components/ComponentInstance.vue
@@ -66,7 +66,9 @@ export default {
     },
     sortedChildren () {
       return this.instance.children.slice().sort((a, b) => {
-        return a.top - b.top
+        return a.top === b.top
+          ? a.id - b.id
+          : a.top - b.top
       })
     }
   },


### PR DESCRIPTION
## Summary

When a component instances are iterated via `v-for` and has more than 10 instances, the sorted order of the instances in the ComponentTree becomes broken. 

## Minimal Reproduction of the bug

```html
<!doctype html>
<html>
  <head>
    <script src="https://unpkg.com/vue"></script>
  </head>
  <body>
    <div id="app">
      <table>
        <tbody>
          <tr v-for="row in rows">
            <td v-for="val in row" is="td_component" :val="val">
            </td>
          </tr>
        </tbody>
      </table>
    </div>

    <script id="td_component" type="x-template">
      <td>
        {{ val }}
      </td>
    </script>

    <script type="text/javascript">
      td_component = {
        props: ['val'],
        template: '#td_component'
      }

      new Vue({
        el: '#app',
        data: {
          rows: [
            Array.apply(null, {length: 11}).map(Number.call, Number), // => [0,1,2,3,4,5,6,7,8,9,10]
          ]
        },
        components: {
          td_component: Vue.extend(td_component),
        }
      })
    </script>
  </body>
</html>
```

`ComponentInstance.sortedChildren()` had been introduced at https://github.com/vuejs/vue-devtools/commit/4f29d96b990ee5915d88455d7695eb497b3682ae#diff-ce57b9b0e36461ce34f203f85e29b2b0R83, however, I couldn't figure out the reason why it's being sorted with the `top` property instead of `id`, which is causing the instances getting mixed up despite of its iteration order. 

As you can see below, this PR fixes the instances to be properly ordered. I've also tested it out on my personal project with many large, complex component trees, but it seemed to be working fine.

Let me know if there's anything I'm missing out. Btw, congrats on the awesome tool!

## Results

### BEFORE

<img src="https://cloud.githubusercontent.com/assets/1957801/24434419/5bd520b0-146a-11e7-869e-66ad92bba0c6.gif" width="450">

### AFTER

<img src="https://cloud.githubusercontent.com/assets/1957801/24434418/5bced804-146a-11e7-8652-fd08fa4a4139.gif" width="450">