### PR TITLE
Fix: RegExp are displayed as empty objects.

### DIFF
--- a/shells/dev/target/index.js
+++ b/shells/dev/target/index.js
@@ -27,7 +27,8 @@ new Vue({
   data: {
     obj: {
       items: items,
-      circular
+      circular,
+      regexp: /([a-z]+)/g
     }
   }
 }).$mount('#app')

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -37,7 +37,7 @@
 <script>
 import { UNDEFINED, INFINITY, isPlainObject } from 'src/util'
 
-const rawTypeRE = /^\[object (\w+)]$/
+const rawTypeRE = /^\[object (.+)\]$/
 
 export default {
   name: 'DataField',

--- a/src/util.js
+++ b/src/util.js
@@ -43,7 +43,9 @@ export function stringify (data) {
 }
 
 function replacer (key, val) {
-  if (val === undefined) {
+  if (val instanceof RegExp) {
+    return '[object ' + val.toString() + ']'
+  } else if (val === undefined) {
     return UNDEFINED
   } else if (val === Infinity) {
     return INFINITY

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -20,6 +20,7 @@ module.exports = {
       .assert.containsText('.component-name', 'Root')
       .assert.elementPresent('.data-field')
       .assert.containsText('.data-field', 'obj:Object')
+      .assert.containsText('.data-field', 'regexp:/([a-z]+)/g')
 
       // should expand root by default
       .assert.count('.instance', baseInstanceCount)


### PR DESCRIPTION
This fix vuejs/vue-devtools#276
`const rawTypeRE = /^\[object (\w+)]$/` is invalid.....
`const rawTypeRE = /^\[object (.+)\]$/` is valid