### PR TITLE
Event modifier added

### DIFF
--- a/src/devtools/components/SplitPane.vue
+++ b/src/devtools/components/SplitPane.vue
@@ -6,7 +6,7 @@
     :class="{ dragging: dragging }">
     <div class="left" :style="{ width: split + '%' }">
       <slot name="left"></slot>
-      <div class="dragger" @mousedown="dragStart">
+      <div class="dragger" @mousedown.prevent="dragStart">
       </div>
     </div>
     <div class="right" :style="{ width: (100 - split) + '%' }">


### PR DESCRIPTION
Prevents text selection.

Before:
![drag-before](https://cloud.githubusercontent.com/assets/1490347/25777926/feb9f058-32c4-11e7-965f-6e89707e48d3.gif)

After: 
![drag-after](https://cloud.githubusercontent.com/assets/1490347/25777927/0626dff4-32c5-11e7-9313-40596e6a8dbc.gif)
