### PR TITLE
Support regex

### DIFF
--- a/shells/dev/target/Other.vue
+++ b/shells/dev/target/Other.vue
@@ -42,8 +42,7 @@ export default {
           e: undefined,
           f: true,
           g: 12345,
-          h: 'I am a really long string mostly just to see how the horizontal scrolling works.',
-          i: new RegExp('12345', 'ig'),
+          h: 'I am a really long string mostly just to see how the horizontal scrolling works.'
         }
       }
     }

--- a/shells/dev/target/Other.vue
+++ b/shells/dev/target/Other.vue
@@ -43,6 +43,7 @@ export default {
           f: true,
           g: 12345,
           h: 'I am a really long string mostly just to see how the horizontal scrolling works.',
+          i: new RegExp('12345', 'ig'),
         }
       }
     }

--- a/shells/dev/target/Target.vue
+++ b/shells/dev/target/Target.vue
@@ -1,6 +1,10 @@
 <template>
   <div id="target">
     <h1>{{localMsg}}</h1>
+    <span>Regex: {{regex.toString()}}</span>
+    <input @keyup.enter="regex = new RegExp($event.target.value)"/>
+    <span>(Press enter to set)</span>
+    <br/>
     <button class="add" @click="add">Add</button>
     <button class="remove" @click="rm">Remove</button>
     <input v-model="localMsg">
@@ -18,10 +22,11 @@ export default {
     obj: null,
     ins: MyClass
   },
-  data() {
+  data () {
     return {
       localMsg: this.msg,
-      items: [1, 2]
+      items: [1, 2],
+      regex: /(a\w+b)/g
     }
   },
   computed: {

--- a/shells/dev/target/Target.vue
+++ b/shells/dev/target/Target.vue
@@ -26,7 +26,9 @@ export default {
     return {
       localMsg: this.msg,
       items: [1, 2],
-      regex: /(a\w+b)/g
+      regex: /(a\w+b)/g,
+      nan: NaN,
+      infinity: Infinity
     }
   },
   computed: {

--- a/shells/dev/target/index.js
+++ b/shells/dev/target/index.js
@@ -27,8 +27,7 @@ new Vue({
   data: {
     obj: {
       items: items,
-      circular,
-      regexp: /([a-z]+)/g
+      circular
     }
   }
 }).$mount('#app')

--- a/shells/dev/target/index.js
+++ b/shells/dev/target/index.js
@@ -27,7 +27,8 @@ new Vue({
   data: {
     obj: {
       items: items,
-      circular
+      circular,
+      regexp: /([a-z]+)/g
     }
   }
 }).$mount('#app')

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -38,7 +38,7 @@
 import { UNDEFINED, INFINITY, isPlainObject } from 'src/util'
 
 const rawTypeRE = /^\[object (\w+)]$/
-const regExpRE = /^(\/.*?\/\w*)/
+const specialTypeRE = /^\[object \w+ (.*)\]$/
 
 export default {
   name: 'DataField',
@@ -60,10 +60,9 @@ export default {
         return 'null'
       } else if (type === 'boolean' || type === 'number' || value === INFINITY) {
         return 'literal'
-      } else if (
-        value instanceof RegExp ||
-        (type === 'string' && !rawTypeRE.test(value))
-      ) {
+      } else if (specialTypeRE.test(value)) {
+        return 'native'
+      } else if (type === 'string' && !rawTypeRE.test(value)) {
         return 'string'
       }
     },
@@ -83,12 +82,10 @@ export default {
         return 'Array[' + value.length + ']'
       } else if (isPlainObject(value)) {
         return 'Object' + (Object.keys(value).length ? '' : ' (empty)')
+      } else if (this.valueType === 'native') {
+        return specialTypeRE.exec(value)[1]
       } else if (typeof value === 'string') {
-        var regexMatch = value.match(regExpRE)
         var typeMatch = value.match(rawTypeRE)
-        if (regexMatch) {
-          return regexMatch[1]
-        }
         if (typeMatch) {
           return typeMatch[1]
         } else {
@@ -160,7 +157,7 @@ export default {
     position relative
   .value
     color #444
-    &.string
+    &.string, &.native
       color #c41a16
     &.null
       color #999
@@ -217,7 +214,7 @@ export default {
       color: #e36eec
     .value
       color #bdc6cf
-      &.string
+      &.string, &.native
         color #e33e3a
       &.null
         color #999

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -35,7 +35,12 @@
 </template>
 
 <script>
-import { UNDEFINED, INFINITY, isPlainObject } from 'src/util'
+import {
+  UNDEFINED,
+  INFINITY,
+  NAN,
+  isPlainObject
+} from 'src/util'
 
 const rawTypeRE = /^\[object (\w+)]$/
 const specialTypeRE = /^\[object \w+ (.*)\]$/
@@ -58,7 +63,12 @@ export default {
       const type = typeof value
       if (value == null || value === UNDEFINED) {
         return 'null'
-      } else if (type === 'boolean' || type === 'number' || value === INFINITY) {
+      } else if (
+        type === 'boolean' ||
+        type === 'number' ||
+        value === INFINITY ||
+        value === NAN
+      ) {
         return 'literal'
       } else if (specialTypeRE.test(value)) {
         return 'native'
@@ -76,6 +86,8 @@ export default {
         return 'null'
       } else if (value === UNDEFINED) {
         return 'undefined'
+      } else if (value === NAN) {
+        return 'NaN'
       } else if (value === INFINITY) {
         return 'Infinity'
       } else if (Array.isArray(value)) {

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -37,7 +37,7 @@
 <script>
 import { UNDEFINED, INFINITY, isPlainObject } from 'src/util'
 
-const rawTypeRE = /^\[object (\w+)]$/
+const rawTypeRE = /^\[object (.+)\]$/
 
 export default {
   name: 'DataField',

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -37,7 +37,8 @@
 <script>
 import { UNDEFINED, INFINITY, isPlainObject } from 'src/util'
 
-const rawTypeRE = /^\[object (.+)\]$/
+const rawTypeRE = /^\[object (\w+)]$/
+const regExpRE = /^(\/.*?\/\w*)/
 
 export default {
   name: 'DataField',
@@ -83,14 +84,16 @@ export default {
       } else if (isPlainObject(value)) {
         return 'Object' + (Object.keys(value).length ? '' : ' (empty)')
       } else if (typeof value === 'string') {
+        var regexMatch = value.match(regExpRE)
         var typeMatch = value.match(rawTypeRE)
+        if (regexMatch) {
+          return regexMatch[1]
+        }
         if (typeMatch) {
           return typeMatch[1]
         } else {
           return JSON.stringify(value)
         }
-      } else if (value instanceof RegExp) {
-        return value.toString()
       } else {
         return value
       }

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -43,7 +43,7 @@ import {
 } from 'src/util'
 
 const rawTypeRE = /^\[object (\w+)]$/
-const specialTypeRE = /^\[object \w+ (.*)\]$/
+const specialTypeRE = /^\[native \w+ (.*)\]$/
 
 export default {
   name: 'DataField',

--- a/src/util.js
+++ b/src/util.js
@@ -37,6 +37,7 @@ export function inDoc (node) {
 
 export const UNDEFINED = '__vue_devtool_undefined__'
 export const INFINITY = '__vue_devtool_infinity__'
+export const NAN = '__vue_devtool_nan__'
 
 export function stringify (data) {
   return CircularJSON.stringify(data, replacer)
@@ -47,6 +48,8 @@ function replacer (key, val) {
     return UNDEFINED
   } else if (val === Infinity) {
     return INFINITY
+  } else if (Number.isNaN(val)) {
+    return NAN
   } else if (val instanceof RegExp) {
     // special handling of native type
     return `[object RegExp ${val.toString()}]`
@@ -66,6 +69,8 @@ function reviver (key, val) {
     return undefined
   } else if (val === INFINITY) {
     return Infinity
+  } else if (val === NAN) {
+    return NaN
   } else {
     return val
   }

--- a/src/util.js
+++ b/src/util.js
@@ -52,7 +52,7 @@ function replacer (key, val) {
     return NAN
   } else if (val instanceof RegExp) {
     // special handling of native type
-    return `[object RegExp ${val.toString()}]`
+    return `[native RegExp ${val.toString()}]`
   } else {
     return sanitize(val)
   }

--- a/src/util.js
+++ b/src/util.js
@@ -43,7 +43,9 @@ export function stringify (data) {
 }
 
 function replacer (key, val) {
-  if (val === undefined) {
+  if (val instanceof RegExp) {
+    return '[object ' + val.toString() + ']'
+  } else if (val === undefined) {
     return UNDEFINED
   } else if (val === Infinity) {
     return INFINITY

--- a/src/util.js
+++ b/src/util.js
@@ -43,12 +43,13 @@ export function stringify (data) {
 }
 
 function replacer (key, val) {
-  if (val instanceof RegExp) {
-    return '[object ' + val.toString() + ']'
-  } else if (val === undefined) {
+  if (val === undefined) {
     return UNDEFINED
   } else if (val === Infinity) {
     return INFINITY
+  } else if (val instanceof RegExp) {
+    // special handling of native type
+    return `[object RegExp ${val.toString()}]`
   } else {
     return sanitize(val)
   }
@@ -80,9 +81,7 @@ function reviver (key, val) {
  */
 
 function sanitize (data) {
-  if (isRegExp(data)) {
-    return RegExp.prototype.toString.call(data)
-  } else if (
+  if (
     !isPrimitive(data) &&
     !Array.isArray(data) &&
     !isPlainObject(data)
@@ -109,10 +108,6 @@ function isPrimitive (data) {
     type === 'number' ||
     type === 'boolean'
   )
-}
-
-function isRegExp (data) {
-  return data instanceof RegExp
 }
 
 export function searchDeepInObject (obj, searchTerm) {

--- a/src/util.js
+++ b/src/util.js
@@ -80,7 +80,9 @@ function reviver (key, val) {
  */
 
 function sanitize (data) {
-  if (
+  if (isRegExp(data)) {
+    return RegExp.prototype.toString.call(data)
+  } else if (
     !isPrimitive(data) &&
     !Array.isArray(data) &&
     !isPlainObject(data)
@@ -105,9 +107,12 @@ function isPrimitive (data) {
   return (
     type === 'string' ||
     type === 'number' ||
-    type === 'boolean' ||
-    data instanceof RegExp
+    type === 'boolean'
   )
+}
+
+function isRegExp (data) {
+  return data instanceof RegExp
 }
 
 export function searchDeepInObject (obj, searchTerm) {

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -20,7 +20,6 @@ module.exports = {
       .assert.containsText('.component-name', 'Root')
       .assert.elementPresent('.data-field')
       .assert.containsText('.data-field', 'obj:Object')
-      .assert.containsText('.data-field', 'regexp:/([a-z]+)/g')
 
       // should expand root by default
       .assert.count('.instance', baseInstanceCount)
@@ -38,6 +37,8 @@ module.exports = {
       .assert.containsText('.data-el.props .data-field:nth-child(1)', 'ins:\nObject')
       .assert.containsText('.data-el.props .data-field:nth-child(2)', 'msg:\n"hi"')
       .assert.containsText('.data-el.props .data-field:nth-child(3)', 'obj:\nundefined')
+      // Regexp
+      .assert.containsText('.data-el.data .data-field:nth-child(3)', 'regex:/(a\\w+b)/g')
 
       // expand child instance
       .click('.instance .instance:nth-child(2) .arrow-wrapper')

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -20,6 +20,7 @@ module.exports = {
       .assert.containsText('.component-name', 'Root')
       .assert.elementPresent('.data-field')
       .assert.containsText('.data-field', 'obj:Object')
+      .assert.containsText('.data-field', 'regexp:/([a-z]+)/g')
 
       // should expand root by default
       .assert.count('.instance', baseInstanceCount)

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -38,7 +38,10 @@ module.exports = {
       .assert.containsText('.data-el.props .data-field:nth-child(2)', 'msg:\n"hi"')
       .assert.containsText('.data-el.props .data-field:nth-child(3)', 'obj:\nundefined')
       // Regexp
-      .assert.containsText('.data-el.data .data-field:nth-child(3)', 'regex:/(a\\w+b)/g')
+      .assert.containsText('.data-el.data .data-field:nth-child(5)', 'regex:/(a\\w+b)/g')
+      // Literals
+      .assert.containsText('.data-el.data .data-field:nth-child(4)', 'NaN')
+      .assert.containsText('.data-el.data .data-field:nth-child(1)', 'Infinity')
 
       // expand child instance
       .click('.instance .instance:nth-child(2) .arrow-wrapper')


### PR DESCRIPTION
Closes #276

Add support for native types like Regexp. To add a new native type (eg: Symbol), we have to update the replacer function in util

It looks like:
<img width="649" alt="screen shot 2017-05-10 at 15 40 31" src="https://cloud.githubusercontent.com/assets/664177/25901415/0c47b2d0-3597-11e7-9c94-c0f15044d138.png">

<img width="674" alt="screen shot 2017-05-10 at 15 41 35" src="https://cloud.githubusercontent.com/assets/664177/25901458/2d81b6da-3597-11e7-9493-926e1e7e06ad.png">

Which is the same colour of the devtools