### PR TITLE
Disable expanding large objects/arrays by default

### DIFF
--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -39,6 +39,16 @@ import { UNDEFINED, INFINITY, isPlainObject } from 'src/util'
 
 const rawTypeRE = /^\[object (\w+)]$/
 
+function subFieldCount (value) {
+  if (Array.isArray(value)) {
+    return value.length
+  } else if (typeof value === 'object') {
+    return Object.keys(value).length
+  } else {
+    return 0
+  }
+}
+
 export default {
   name: 'DataField',
   props: {
@@ -48,7 +58,7 @@ export default {
   data () {
     return {
       limit: Array.isArray(this.field.value) ? 10 : Infinity,
-      expanded: this.depth === 0 && this.field.key !== '$route'
+      expanded: this.depth === 0 && this.field.key !== '$route' && (subFieldCount(this.field.value) < 5)
     }
   },
   computed: {


### PR DESCRIPTION
This is for issue #123. This change disables auto-expansion of root-level objects if they have more than 4 subfields.

Alternatively, this could be implemented as a per-user option (or an option in the current page's Vue config), but since there aren't currently any other devtool config settings I thought it might be best to just implement it directly like this.

Let me know if there are any issues, thanks!