### PR TITLE
Improve dark mode colors for inactive items in the Events and Vuex panes

### DIFF
--- a/src/devtools/views/events/EventsHistory.vue
+++ b/src/devtools/views/events/EventsHistory.vue
@@ -116,6 +116,7 @@ export default {
     .event-source
       color #ddd
   .app.dark &
+    color #e36eec
     background-color $dark-background-color
 
 .time

--- a/src/devtools/views/vuex/VuexHistory.vue
+++ b/src/devtools/views/vuex/VuexHistory.vue
@@ -181,8 +181,12 @@ $inspected_color = #af90d5
       display inline-block
   .app.dark &
     background-color $dark-background-color
+    .mutation-type
+      color #e36eec
     &.active
       background-color $active-color
+      .mutation-type
+        color #fff
 
 .action
   color #999


### PR DESCRIPTION
This makes the purple color used in the left side of these panes match the brighter purple color used in the right side.

Vuex before:
![image](https://cloud.githubusercontent.com/assets/1619746/25975246/1282c74a-3662-11e7-9c0a-a9c37238eb81.png)

Vuex after:
![image](https://cloud.githubusercontent.com/assets/1619746/25975255/17c6079e-3662-11e7-9174-8673cad5ad61.png)

Events before:
![image](https://cloud.githubusercontent.com/assets/1619746/25975283/37416780-3662-11e7-8a8d-e7203bff109a.png)

Events after:
![image](https://cloud.githubusercontent.com/assets/1619746/25975288/3b9ab5c0-3662-11e7-9c9a-cc67ecd43e78.png)
