### PR TITLE
[Proposal] More Verbose Component Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ Currently only a Chrome devtools extension is available.
 5. Check "developer mode"
 6. Click "load unpacked extension", and choose `shells/chrome`.
 
+### Optional Usage
+
+Implement a computed value `instanceName` in your components to make the component tree be more verbose.
+
+The following example could have the component be rendered as
+`<Person: Evan You>` instead of `<Person>`.
+
+```
+export default {
+  name: 'Person',
+  props: ['name']
+  computed: {
+    instanceName () { return this.name }
+  }
+}
+```
+
 ### Hacking
 
 1. Clone this repo

--- a/shells/dev/target/People.vue
+++ b/shells/dev/target/People.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="people">
+    <h1>People</h1>
+    <p>This demonstrates how having an individual Component Name can be beneficial for lists.</p>
+    <person first-name="Evan" last-name="You" />
+    <person first-name="Gambo" />
+  </div>
+</template>
+
+<script>
+import Person from './Person.vue'
+
+export default {
+  name: 'People',
+  components: { Person },
+  computed: {
+    instanceName () {
+      return 'Open Me'
+    }
+  }
+}
+</script>

--- a/shells/dev/target/Person.vue
+++ b/shells/dev/target/Person.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="person">
+    Person: {{ fullName }}
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'Person',
+  props: ['firstName', 'lastName'],
+  computed: {
+    fullName () {
+      return [this.firstName, this.lastName]
+               .filter(item => item !== undefined)
+               .join(' ')
+    },
+    instanceName () {
+      return this.fullName
+    }
+  }
+}
+</script>

--- a/shells/dev/target/index.js
+++ b/shells/dev/target/index.js
@@ -4,6 +4,7 @@ import Target from './Target.vue'
 import Other from './Other.vue'
 import Counter from './Counter.vue'
 import Events from './Events.vue'
+import People from './People.vue'
 import MyClass from './MyClass.js'
 
 let items = []
@@ -21,6 +22,7 @@ new Vue({
       h(Counter),
       h(Target, {props:{msg: 'hi', ins: new MyClass()}}),
       h(Other),
+      h(People),
       h(Events)
     ])
   },

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -319,6 +319,9 @@ function getInstanceDetails (id) {
 
 /**
  * Get the appropriate display name for an instance.
+ * Looks if the instance provides an individual `instanceName`
+ * and adds it to the component's name.
+ * e.g. to render this: <Person: Christian Gambardella>
  *
  * @param {Vue} instance
  * @return {String}
@@ -327,7 +330,12 @@ function getInstanceDetails (id) {
 export function getInstanceName (instance) {
   const name = instance.$options.name || instance.$options._componentTag
   if (name) {
-    return classify(name)
+    let instanceName
+    if (instance.instanceName !== undefined) {
+      // convert to String in the odd case that the returned value is 0.
+      instanceName = `${instance.instanceName}`
+    }
+    return instanceName ? `${classify(name)}: ${instanceName}` : classify(name)
   }
   const file = instance.$options.__file // injected by vue-loader
   if (file) {

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -1,6 +1,6 @@
 module.exports = {
   'vue-devtools e2e tests': function (browser) {
-    var baseInstanceCount = 6
+    var baseInstanceCount = 7
 
     browser
     .url('http://localhost:' + (process.env.PORT || 8081))
@@ -30,6 +30,17 @@ module.exports = {
       .assert.containsText('.data-el.vuex-bindings .data-field', 'count:0')
       .assert.containsText('.data-el.computed .data-field', 'test:1')
       .assert.containsText('.data-el.firebase-bindings .data-field', 'hello:undefined')
+
+      // instance names
+      .click('.instance .instance:nth-child(4) .arrow-wrapper')
+      .click('.instance .instance:nth-child(4) .self')
+      .assert.containsText('.component-name', 'People: Open Me')
+      .click('.instance .instance:nth-child(4) .instance:nth-child(1) .self')
+      .assert.containsText('.component-name', 'Person: Evan You')
+      .click('.instance .instance:nth-child(4) .instance:nth-child(2) .self')
+      .assert.containsText('.component-name', 'Person: Gambo')
+      // close again
+      .click('.instance .instance:nth-child(4) .arrow-wrapper')
 
       // prop types
       .click('.instance .instance:nth-child(2) .self')


### PR DESCRIPTION
Someone on Stackoverflow was asking if it was possible to show individual component names in the component tree.

Subconsciously I always wanted this as well.
So why not give it a shot.

It works by implementing an optional computed value `instanceName` in the components.

![plain_shell_und_vue-devtools_ _working_copy__master_ _0_changed_files_](https://cloud.githubusercontent.com/assets/449438/25989145/586a07e8-36fb-11e7-9992-386d8be71f00.png)

This could be useful for lists but also for input components to show the name of the input.

```
Like:
<TextInput: first-name>
<TextInput: last-name>
<TextAreaInput: bio>
```

- It has a note in the README.md
- It has tests for the names
- All previous tests still pass

Please let me know if there are any suggestions or critique.

Stackoverflow:
https://stackoverflow.com/questions/40936918/how-to-distinguish-between-component-instances-in-vue-devtools

Best,
Christian