### PR TITLE
Add the extra slash to the file:///* match pattern

### DIFF
--- a/shells/chrome/manifest.json
+++ b/shells/chrome/manifest.json
@@ -32,7 +32,7 @@
   "permissions": [
     "http://*/*",
     "https://*/*",
-    "file://*"
+    "file:///*"
   ],
 
   "content_scripts": [


### PR DESCRIPTION
This is part of the work required to make #57 happen (as a pure WebExtension in Firefox)

The `file://*` match pattern is supposed to have 3 slashes so its actually `file:///*`.  

Chrome ignores the issue but their docs do ask for it:  https://developer.chrome.com/extensions/match_patterns

MDN has a specific warning about this: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Match_patterns#Invalid_match_patterns

Tested `file:///.../todomvc/examples/vue/index.html` in Chrome and Firefox.