### PR TITLE
Firefox WebExtension support

### DIFF
--- a/shells/chrome/devtools-background.html
+++ b/shells/chrome/devtools-background.html
@@ -1,1 +1,2 @@
+<meta charset="utf-8">
 <script src="./build/devtools-background.js"></script>

--- a/shells/chrome/manifest.json
+++ b/shells/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Vue.js devtools",
   "version": "3.1.3",
-  "description": "Chrome devtools extension for debugging Vue.js applications.",
+  "description": "Chrome and Firefox DevTools extension for debugging Vue.js applications.",
   "manifest_version": 2,
   "icons": {
     "16": "icons/16.png",

--- a/shells/chrome/popups/disabled.html
+++ b/shells/chrome/popups/disabled.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <p style="width: 200px">
   Vue.js is detected on this page.
   Devtools inspection is not available because it's in

--- a/shells/chrome/popups/enabled.html
+++ b/shells/chrome/popups/enabled.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
 <p style="width: 180px;">
   Vue.js is detected on this page.
-  Open Chrome Devtools and look for the Vue panel.
+  Open DevTools and look for the Vue panel.
 </p>

--- a/shells/chrome/popups/enabled.html
+++ b/shells/chrome/popups/enabled.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <p style="width: 180px;">
   Vue.js is detected on this page.
   Open Chrome Devtools and look for the Vue panel.

--- a/shells/chrome/popups/not-found.html
+++ b/shells/chrome/popups/not-found.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <p style="white-space: nowrap">
   Vue.js not detected
 </p>

--- a/shells/chrome/webpack.config.js
+++ b/shells/chrome/webpack.config.js
@@ -3,7 +3,7 @@ var webpack = require('webpack')
 var alias = require('../alias')
 
 var bubleOptions = {
-  target: process.env.NODE_ENV === 'production' ? null : { chrome: 52 },
+  target: process.env.NODE_ENV === 'production' ? null : { chrome: 52, firefox: 48 },
   objectAssign: 'Object.assign'
 }
 

--- a/shells/dev/webpack.config.js
+++ b/shells/dev/webpack.config.js
@@ -4,7 +4,7 @@ var alias = require('../alias')
 var FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
 
 var bubleOptions = {
-  target: { chrome: 52 },
+  target: { chrome: 52, firefox: 48 },
   objectAssign: 'Object.assign'
 }
 


### PR DESCRIPTION
This is the last set of pieces to get #57 closed and is part of the followup work to #340 

This PR needs to wait on Firefox to land the work [bug 1300590](https://bugzilla.mozilla.org/show_bug.cgi?id=1300590) such that `$0` and `inspect` bindings will work in the `devtools.inspectedWindow.eval` API.  However the patch in bugzilla is in the final throws so I wanted to get these changes up and available.