### PR TITLE
Fix issue #345 with undefined  for instantiating routes on the before…

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -272,7 +272,7 @@ function capture (instance, _, list) {
   const isRouterView2 = instance.$vnode && instance.$vnode.data.routerView
   if (instance._routerView || isRouterView2) {
     ret.isRouterView = true
-    if (!instance._inactive) {
+    if (!instance._inactive && instance.$route) {
       const matched = instance.$route.matched
       const depth = isRouterView2
         ? instance.$vnode.data.routerViewDepth


### PR DESCRIPTION
Fixes #345.

By default it always assumes that the instance has a $router, but in my case $route did not have any routes when the DevTools where instantiated, so it was failing trying to get the `matched` route.

With this fix we ensure that $route exists.