### PR TITLE
Make Vuex store objects collapsed by default

### DIFF
--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -64,7 +64,7 @@ export default {
   data () {
     return {
       limit: Array.isArray(this.field.value) ? 10 : Infinity,
-      expanded: this.depth === 0 && this.field.key !== '$route' && (subFieldCount(this.field.value) < 5)
+      expanded: this.depth === 0 && this.field.key !== '$route' && (subFieldCount(this.field.value) < 1)
     }
   },
   computed: {


### PR DESCRIPTION
Fix for https://github.com/vuejs/vue-devtools/issues/324 / https://github.com/vuejs/vue-devtools/issues/123

Note: This makes all values collapsed by default. Changing this line makes it way more trivial to work with a project with a lot of Vuex modules 👍 