### PR TITLE
Checks that document.doctype is an HTML doc before injecting

### DIFF
--- a/shells/chrome/src/detector.js
+++ b/shells/chrome/src/detector.js
@@ -27,8 +27,10 @@ function detect (win) {
   }, 100)
 }
 
-// inject the hook
-const script = document.createElement('script')
-script.textContent = ';(' + detect.toString() + ')(window)'
-document.documentElement.appendChild(script)
-script.parentNode.removeChild(script)
+// inject the hook, avoid non HTML pages
+if (document.doctype !== null) {
+  const script = document.createElement('script')
+  script.textContent = ';(' + detect.toString() + ')(window)'
+  document.documentElement.appendChild(script)
+  script.parentNode.removeChild(script)
+}

--- a/shells/chrome/src/hook.js
+++ b/shells/chrome/src/hook.js
@@ -1,8 +1,10 @@
 // This script is injected into every page.
 import { installHook } from 'src/backend/hook'
 
-// inject the hook
-const script = document.createElement('script')
-script.textContent = ';(' + installHook.toString() + ')(window)'
-document.documentElement.appendChild(script)
-script.parentNode.removeChild(script)
+// inject the hook, avoid non HTML pages
+if (document.doctype !== null) {
+  const script = document.createElement('script')
+  script.textContent = ';(' + installHook.toString() + ')(window)'
+  document.documentElement.appendChild(script)
+  script.parentNode.removeChild(script)
+}


### PR DESCRIPTION
This fixes #356

The document.doctype should always be defined for HTML documents.  See https://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-B63ED1A31

Guarding against this should protect from injecting the content scripts into non-HTML pages.

Tested in Firefox and Chrome.