### PR TITLE
Fixed StateInspector scrollbars on Firefox (Except on MacOS)

### DIFF
--- a/src/devtools/components/ScrollPane.vue
+++ b/src/devtools/components/ScrollPane.vue
@@ -47,7 +47,7 @@ export default {
 
 .scroll
   flex 1
-  overflow overlay
+  overflow auto
   .app.dark &::-webkit-scrollbar
     background: $dark-background-color
     border-left: 1px solid $dark-border-color


### PR DESCRIPTION
**Resolves #355**
ScrollPane.vue was using "overflow overlay" which is not supported in
Firefox. Changing this to "overflow auto" fixes scrolling
in Firefox while not impacting UI or functionality in Chrome.