### PR TITLE
Add __VUE_DEVTOOLS_CONTEXT__ to allow for iframe compatibility

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -106,7 +106,7 @@ function scan () {
   rootInstances.length = 0
   let inFragment = false
   let currentFragment = null
-  walk(document, function (node) {
+  walk(window.__VUE_DEVTOOLS_CONTEXT__ || document, function (node) {
     if (inFragment) {
       if (node === currentFragment._fragmentEnd) {
         inFragment = false


### PR DESCRIPTION
Hi, I'm currently creating this PR as a discussion point to possibly solve some of the issues around using Devtools to identify apps within iframes [1](https://github.com/vuejs/vue-devtools/issues/353), [2 (last bullet point)](https://github.com/vuejs/vue-devtools/issues/354).

The stopgap solution I'm proposing here would check for a global `__VUE_DEVTOOLS_CONTEXT__` variable on the target document. This would allow for an application like `storybook` or `vue-play` to define the context in which the devtools would run. I.e. https://github.com/storybooks/storybook/pull/1376/files

This may not be the perfect way to go but it's currently the solution I'm using locally to develop and I figured it might be helpful to bring up here. 