### PR TITLE
make search input as large as possible

### DIFF
--- a/src/devtools/components/ActionHeader.vue
+++ b/src/devtools/components/ActionHeader.vue
@@ -63,6 +63,7 @@
 .search
   display flex
   align-items center
+  flex 1
   input
     flex 1
     height 100%


### PR DESCRIPTION
should be able to focus search input by clicking blank area of ActionHeader