### PR TITLE
feat(log): add styling to console message

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -94,7 +94,12 @@ function connect () {
 
   bridge.log('backend ready.')
   bridge.send('ready', hook.Vue.version)
-  console.log('[vue-devtools] Ready. Detected Vue v' + hook.Vue.version)
+  console.log(
+    `%c vue-devtools %c Detected Vue v${hook.Vue.version} %c`,
+    'background:#35495e ; padding: 1px; border-radius: 3px 0 0 3px;  color: #fff',
+    'background:#41b883 ; padding: 1px; border-radius: 0 3px 3px 0;  color: #fff',
+    'background:transparent'
+  )
   scan()
 }
 


### PR DESCRIPTION
Closes #398
Thanks to @P9Q

I changed the message to be a bit more concise as well. I thought it was a bit too long with two boxes and that _Ready_ was redundant.

<img width="435" alt="screen shot 2017-09-05 at 00 10 33" src="https://user-images.githubusercontent.com/664177/30039256-c9157ad0-91ce-11e7-8d2f-4ee0ec1842d6.png">