### PR TITLE
toggle component tree with doubleclick

### DIFF
--- a/src/devtools/views/components/ComponentInstance.vue
+++ b/src/devtools/views/components/ComponentInstance.vue
@@ -6,6 +6,7 @@
     }">
     <div class="self"
       @click.stop="select"
+      @dblclick.stop="toggle"
       @mouseenter="enter"
       @mouseleave="leave"
       :class="{ selected: selected }"


### PR DESCRIPTION
Just a simple feature, that makes navigating component tree a little more pleasant. I often found myself frustrated that I had to point to caret to open up the tree. Now you can just double click while hovering over component in the tree to open it.