### PR TITLE
fix event hook

### DIFF
--- a/src/backend/hook.js
+++ b/src/backend/hook.js
@@ -21,9 +21,10 @@ export function installHook (window) {
     },
 
     once (event, fn) {
+      const event_alias = event;
       event = '$' + event
       function on () {
-        this.off(event, on)
+        this.off(event_alias, on)
         fn.apply(this, arguments)
       }
       ;(listeners[event] || (listeners[event] = [])).push(on)


### PR DESCRIPTION
Once an event, the event will not be removed. Because this event name become `$$event` in the off function.
