### PR TITLE
Select component from dom tree

### DIFF
--- a/shells/dev/target/Other.vue
+++ b/shells/dev/target/Other.vue
@@ -32,7 +32,7 @@ export default {
   },
   components: {
     mine: {
-      render: h => h('div', null, 'mine'),
+      render: h => h('div', { class: 'mine' }, 'mine'),
       data () {
         return {
           // testing all data types
@@ -50,3 +50,8 @@ export default {
   }
 }
 </script>
+
+<style lang="stylus">
+.mine
+  display inline-block
+</style>

--- a/shells/dev/target/Target.vue
+++ b/shells/dev/target/Target.vue
@@ -5,11 +5,19 @@
     <input @keyup.enter="regex = new RegExp($event.target.value)"/>
     <span>(Press enter to set)</span>
     <br/>
-    <button class="add" @click="add">Add</button>
-    <button class="remove" @click="rm">Remove</button>
+    <button class="add" @mouseup="add">Add</button>
+    <button class="remove" @mousedown="rm">Remove</button>
     <input v-model="localMsg">
     <other v-for="item in items" :key="item" :id="item"></other>
-    <button @click="inspect">Inspect component</button>
+    <div>
+      <button
+        class="inspect"
+        @click="inspect"
+        @mouseover="over = true"
+        @mouseout="over = false"
+      >Inspect component</button>
+      <span v-if="over" class="over">Mouse over</span>
+    </div>
   </div>
 </template>
 
@@ -30,7 +38,8 @@ export default {
       regex: /(a\w+b)/g,
       nan: NaN,
       infinity: Infinity,
-      negativeInfinity: -Infinity
+      negativeInfinity: -Infinity,
+      over: false
     }
   },
   computed: {
@@ -46,7 +55,12 @@ export default {
   },
   methods: {
     add () {
-      this.items.push(1, 2, 3)
+      const l = this.items.length
+      this.items.push(
+        l + 1,
+        l + 2,
+        l + 3
+      )
     },
     rm () {
       this.items.pop()
@@ -57,3 +71,20 @@ export default {
   }
 }
 </script>
+
+<style lang="stylus" scoped>
+.inspect
+  border solid 1px black
+  background #eee
+  color black
+  border-radius 2px
+  padding 6px 12px
+  cursor pointer
+  &:hover
+    border-color blue
+    color blue
+
+.over
+  pointer-events none
+  margin-left 12px
+</style>

--- a/src/backend/component-selector.js
+++ b/src/backend/component-selector.js
@@ -1,12 +1,10 @@
 import { highlight, unHighlight } from './highlighter'
-import { stringify } from '../util'
 
 export default class ComponentSelector {
   constructor (bridge, instanceMap) {
     const self = this
     self.bridge = bridge
     self.instanceMap = instanceMap
-    self.listeners = []
     self.bindMethods()
 
     bridge.on('start-component-selector', self.startSelecting)
@@ -62,36 +60,11 @@ export default class ComponentSelector {
     e.preventDefault()
 
     if (this.selectedInstance) {
-      this.listeners.forEach(listener => listener(this.selectedInstance.__VUE_DEVTOOLS_UID__, false))
-      this.expandParent(this.selectedInstance)
+      this.bridge.send('inspect-instance', this.selectedInstance.__VUE_DEVTOOLS_UID__)
     }
 
     this.bridge.send('component-selected')
     this.stopSelecting()
-  }
-
-  /**
-   * Fires event to expand an instance' tree
-   * @param {Vue} child
-   */
-  expandParent (child) {
-    const instance = child.$parent
-
-    if (instance) {
-      this.bridge.send('toggle-instance', stringify({
-        id: instance.__VUE_DEVTOOLS_UID__,
-        expanded: true
-      }))
-      this.expandParent(instance)
-    }
-  }
-
-  /**
-   * Used for listening to event when a component is selected
-   * @param {Function} method
-   */
-  onComponentSelected (method) {
-    this.listeners.push(method)
   }
 
   /**

--- a/src/backend/component-selector.js
+++ b/src/backend/component-selector.js
@@ -61,10 +61,12 @@ export default class ComponentSelector {
   elementClicked (e) {
     e.preventDefault()
 
-    this.listeners.forEach(listener => listener(this.selectedInstance.__VUE_DEVTOOLS_UID__, false))
-    this.expandParent(this.selectedInstance)
-    this.bridge.send('component-selected')
+    if (this.selectedInstance) {
+      this.listeners.forEach(listener => listener(this.selectedInstance.__VUE_DEVTOOLS_UID__, false))
+      this.expandParent(this.selectedInstance)
+    }
 
+    this.bridge.send('component-selected')
     this.stopSelecting()
   }
 

--- a/src/backend/component-selector.js
+++ b/src/backend/component-selector.js
@@ -1,5 +1,5 @@
 import { highlight, unHighlight } from './highlighter'
-import { searchComponent } from './utils'
+import { findRelatedComponent } from './utils'
 
 export default class ComponentSelector {
   constructor (bridge, instanceMap) {
@@ -49,7 +49,7 @@ export default class ComponentSelector {
 
     const el = e.target
     if (el) {
-      this.selectedInstance = searchComponent(el)
+      this.selectedInstance = findRelatedComponent(el)
     }
 
     unHighlight()

--- a/src/backend/component-selector.js
+++ b/src/backend/component-selector.js
@@ -69,7 +69,6 @@ export default class ComponentSelector {
       this.bridge.send('inspect-instance', this.selectedInstance.__VUE_DEVTOOLS_UID__)
     }
 
-    this.bridge.send('component-selected')
     this.stopSelecting()
   }
 

--- a/src/backend/highlighter.js
+++ b/src/backend/highlighter.js
@@ -1,10 +1,23 @@
 import { inDoc } from '../util'
+import { getInstanceName } from './index'
 
 const overlay = document.createElement('div')
 overlay.style.backgroundColor = 'rgba(104, 182, 255, 0.35)'
 overlay.style.position = 'fixed'
 overlay.style.zIndex = '99999999999999'
 overlay.style.pointerEvents = 'none'
+overlay.style.display = 'flex'
+overlay.style.alignItems = 'center'
+overlay.style.justifyContent = 'center'
+overlay.style.borderRadius = '3px'
+const overlayContent = document.createElement('div')
+overlayContent.style.backgroundColor = 'rgba(104, 182, 255, 0.9)'
+overlayContent.style.fontFamily = 'monospace'
+overlayContent.style.fontSize = '11px'
+overlayContent.style.padding = '2px 3px'
+overlayContent.style.borderRadius = '3px'
+overlayContent.style.color = 'white'
+overlay.appendChild(overlayContent)
 
 /**
  * Highlight an instance.
@@ -16,7 +29,10 @@ export function highlight (instance) {
   if (!instance) return
   const rect = getInstanceRect(instance)
   if (rect) {
-    showOverlay(rect)
+    let content = ''
+    const name = getInstanceName(instance)
+    name && (content = `<span style="opacity: .6;">&lt;</span>${name}<span style="opacity: .6;">&gt;</span>`)
+    showOverlay(rect, content)
   }
 }
 
@@ -107,11 +123,14 @@ function getTextRect (node) {
  * @param {Rect}
  */
 
-function showOverlay ({ width = 0, height = 0, top = 0, left = 0 }) {
+function showOverlay ({ width = 0, height = 0, top = 0, left = 0 }, content = '') {
   overlay.style.width = ~~width + 'px'
   overlay.style.height = ~~height + 'px'
   overlay.style.top = ~~top + 'px'
   overlay.style.left = ~~left + 'px'
+
+  overlayContent.innerHTML = content
+
   document.body.appendChild(overlay)
 }
 

--- a/src/backend/hook.js
+++ b/src/backend/hook.js
@@ -1,4 +1,4 @@
-import { searchComponent } from './utils'
+import { findRelatedComponent } from './utils'
 
 // this script is injected into every page.
 
@@ -92,7 +92,7 @@ export function installHook (window) {
     const el = event.target
     if (el) {
       // Search for parent that "is" a component instance
-      const instance = searchComponent(el)
+      const instance = findRelatedComponent(el)
       if (instance) {
         window.__VUE_DEVTOOLS_CONTEXT_MENU_HAS_TARGET__ = true
         window.__VUE_DEVTOOLS_CONTEXT_MENU_TARGET__ = instance

--- a/src/backend/hook.js
+++ b/src/backend/hook.js
@@ -1,3 +1,5 @@
+import { searchComponent } from './utils'
+
 // this script is injected into every page.
 
 /**
@@ -87,13 +89,10 @@ export function installHook (window) {
   // Start recording context menu when Vue is detected
   // event if Vue devtools are not loaded yet
   document.addEventListener('contextmenu', event => {
-    let el = event.target
+    const el = event.target
     if (el) {
       // Search for parent that "is" a component instance
-      while (!el.__vue__ && el.parentElement) {
-        el = el.parentElement
-      }
-      const instance = el.__vue__
+      const instance = searchComponent(el)
       if (instance) {
         window.__VUE_DEVTOOLS_CONTEXT_MENU_HAS_TARGET__ = true
         window.__VUE_DEVTOOLS_CONTEXT_MENU_TARGET__ = instance

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -60,7 +60,13 @@ function connect () {
     }
   })
 
-  bridge.on('select-instance', selectInstance)
+  bridge.on('select-instance', id => {
+    currentInspectedId = id
+    const instance = instanceMap.get(id)
+    bindToConsole(instance)
+    flush()
+    bridge.send('instance-details', stringify(getInstanceDetails(id)))
+  })
 
   bridge.on('scroll-to-instance', id => {
     const instance = instanceMap.get(id)
@@ -78,8 +84,7 @@ function connect () {
 
   bridge.on('leave-instance', unHighlight)
 
-  const componentSelector = new ComponentSelector(bridge, instanceMap)
-  componentSelector.onComponentSelected(selectInstance)
+  new ComponentSelector(bridge, instanceMap)
 
   // Get the instance id that is targeted by context menu
   bridge.on('get-context-menu-target', () => {
@@ -414,24 +419,6 @@ export function getInstanceName (instance) {
   return instance.$root === instance
     ? 'Root'
     : 'Anonymous Component'
-}
-
-/**
- * Select an instance in the component view
- *
- * @param {String} id
- * @param {Boolean} highlightElement
- */
-function selectInstance (id, highlightElement = true) {
-  currentInspectedId = id
-  const instance = instanceMap.get(id)
-  if (instance && highlightElement) {
-    scrollIntoView(instance)
-    highlight(instance)
-  }
-  bindToConsole(instance)
-  flush()
-  bridge.send('instance-details', stringify(getInstanceDetails(id)))
 }
 
 /**

--- a/src/backend/utils.js
+++ b/src/backend/utils.js
@@ -1,4 +1,4 @@
-export function searchComponent (el) {
+export function findRelatedComponent (el) {
   while (!el.__vue__ && el.parentElement) {
     el = el.parentElement
   }

--- a/src/backend/utils.js
+++ b/src/backend/utils.js
@@ -1,0 +1,6 @@
+export function searchComponent (el) {
+  while (!el.__vue__ && el.parentElement) {
+    el = el.parentElement
+  }
+  return el.__vue__
+}

--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -133,8 +133,6 @@ export default {
   background-color $background-color
   display flex
   flex-direction column
-  h1
-    color #42b983
   .dark &
     background-color $dark-background-color
 

--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -11,13 +11,6 @@
       </transition>
     </span>
     <a class="button components"
-      :class="{ active: selecting}"
-      @click="selectElement"
-      title="Select element">
-      <i class="material-icons">location_searching</i>
-      <span class="pane-name">Select element</span>
-    </a>
-    <a class="button components"
       :class="{ active: tab === 'components'}"
       @click="switchTab('components')"
       v-tooltip="'Switch to Components'">
@@ -63,7 +56,6 @@ export default {
   name: 'app',
   data () {
     return {
-      selecting: false,
       isDark: typeof chrome !== 'undefined' &&
         typeof chrome.devtools !== 'undefined' &&
         chrome.devtools.panels.themeName === 'dark'
@@ -113,15 +105,6 @@ export default {
       const activeBar = this.$el.querySelector('.active-bar')
       activeBar.style.left = activeButton.offsetLeft + 'px'
       activeBar.style.width = activeButton.offsetWidth + 'px'
-    },
-    selectElement () {
-      this.selecting = !this.selecting
-
-      if (this.selecting) {
-        bridge.send('select-element')
-      } else {
-        bridge.send('stop-select-element')
-      }
     }
   },
   mounted () {
@@ -131,7 +114,6 @@ export default {
 
     this.updateActiveBar()
     window.addEventListener('resize', this.updateActiveBar)
-    bridge.on('component-selected', () => this.selecting = false)
   },
   destroyed () {
     window.removeEventListener('resize', this.updateActiveBar)

--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -11,6 +11,13 @@
       </transition>
     </span>
     <a class="button components"
+      :class="{ active: selecting}"
+      @click="selectElement"
+      title="Select element">
+      <i class="material-icons">location_searching</i>
+      <span class="pane-name">Select element</span>
+    </a>
+    <a class="button components"
       :class="{ active: tab === 'components'}"
       @click="switchTab('components')"
       v-tooltip="'Switch to Components'">
@@ -54,6 +61,14 @@ import { mapState } from 'vuex'
 
 export default {
   name: 'app',
+  data () {
+    return {
+      selecting: false,
+      isDark: typeof chrome !== 'undefined' &&
+        typeof chrome.devtools !== 'undefined' &&
+        chrome.devtools.panels.themeName === 'dark'
+    }
+  },
   components: {
     components: ComponentsTab,
     vuex: VuexTab,
@@ -98,6 +113,15 @@ export default {
       const activeBar = this.$el.querySelector('.active-bar')
       activeBar.style.left = activeButton.offsetLeft + 'px'
       activeBar.style.width = activeButton.offsetWidth + 'px'
+    },
+    selectElement () {
+      this.selecting = !this.selecting
+
+      if (this.selecting) {
+        bridge.send('select-element')
+      } else {
+        bridge.send('stop-select-element')
+      }
     }
   },
   mounted () {
@@ -107,6 +131,7 @@ export default {
 
     this.updateActiveBar()
     window.addEventListener('resize', this.updateActiveBar)
+    bridge.on('component-selected', () => this.selecting = false)
   },
   destroyed () {
     window.removeEventListener('resize', this.updateActiveBar)

--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -54,13 +54,6 @@ import { mapState } from 'vuex'
 
 export default {
   name: 'app',
-  data () {
-    return {
-      isDark: typeof chrome !== 'undefined' &&
-        typeof chrome.devtools !== 'undefined' &&
-        chrome.devtools.panels.themeName === 'dark'
-    }
-  },
   components: {
     components: ComponentsTab,
     vuex: VuexTab,

--- a/src/devtools/components/ActionHeader.vue
+++ b/src/devtools/components/ActionHeader.vue
@@ -61,8 +61,10 @@
       display inline
 
 .material-icons
-  font-size 18px
+  font-size 16px
   margin-right 0
+  position relative
+  top 1px
   color inherit
   @media (min-width: $wide)
     margin-right 5px

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -123,7 +123,7 @@ function initApp (shell) {
     })
 
     bridge.on('toggle-instance', payload => {
-      store.dispatch('components/toggleInstance', parse(payload))
+      store.commit('components/TOGGLE_INSTANCE', parse(payload))
     })
 
     bridge.on('vuex:init', snapshot => {

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -122,6 +122,10 @@ function initApp (shell) {
       store.commit('components/RECEIVE_INSTANCE_DETAILS', parse(details))
     })
 
+    bridge.on('toggle-instance', payload => {
+      store.dispatch('components/toggleInstance', parse(payload))
+    })
+
     bridge.on('vuex:init', snapshot => {
       store.commit('vuex/INIT', snapshot)
     })

--- a/src/devtools/mixins/keyboard.js
+++ b/src/devtools/mixins/keyboard.js
@@ -1,9 +1,8 @@
-const navMap = {
-  37: 'left',
-  38: 'up',
-  39: 'right',
-  40: 'down'
-}
+export const LEFT = 37
+export const UP = 38
+export const RIGHT = 39
+export const DOWN = 40
+export const S = 83
 
 const activeInstances = []
 
@@ -11,13 +10,11 @@ document.addEventListener('keyup', e => {
   if (e.target.tagName === 'INPUT') {
     return
   }
-  if (navMap[e.keyCode]) {
-    activeInstances.forEach(vm => {
-      if (vm.onKeyNav) {
-        vm.onKeyNav(navMap[e.keyCode])
-      }
-    })
-  }
+  activeInstances.forEach(vm => {
+    if (vm.onKeyUp) {
+      vm.onKeyUp(e)
+    }
+  })
 })
 
 export default {

--- a/src/devtools/transitions.styl
+++ b/src/devtools/transitions.styl
@@ -15,3 +15,11 @@
     transform rotate(0deg)
   100%
     transform rotate(360deg)
+
+@keyframes pulse
+  0%
+    opacity 1
+  50%
+    opacity .2
+  100%
+    opacity 1

--- a/src/devtools/variables.styl
+++ b/src/devtools/variables.styl
@@ -11,10 +11,10 @@ $orange = #DB6B00
 $black = #000000
 
 // The min-width to give icons text...
-$wide = 820px
+$wide = 1050px
 
 // The min-height to give the tools a little more breathing room...
-$tall = 300px
+$tall = 350px
 
 // Theme
 $active-color = $darkerGreen

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -112,7 +112,9 @@ export default {
     }
   },
   mounted () {
-    bridge.on('component-selected', () => this.selecting = false)
+    bridge.on('component-selected', () => {
+      this.selecting = false
+    })
   }
 }
 
@@ -151,7 +153,6 @@ function findByIndex (all, index) {
 <style lang="stylus">
 @import "../../variables"
 
-
 .tree
   padding 5px
 .select-component
@@ -160,5 +161,4 @@ function findByIndex (all, index) {
   cursor pointer
   &.active
     color $active-color
-
 </style>

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -8,7 +8,7 @@
       <a
         class="button select-component"
         :class="{active: selecting}"
-        v-tooltip="'Select component from DOM tree'"
+        v-tooltip="'Select component in the page'"
         @click="toggleSelecting"
       >
         <i class="material-icons">
@@ -22,7 +22,7 @@
          @click="toggleClassifyComponents"
       >
         <i class="material-icons">text_fields</i>
-        <span>Formatting</span>
+        <span>Format</span>
       </a>
     </action-header>
     <div slot="scroll" class="tree">

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -172,10 +172,10 @@ function findByIndex (all, index) {
 
 .tree
   padding 5px
+
 .select-component
-  display flex
-  align-items center
-  cursor pointer
   &.active
     color $active-color
+    .material-icons
+      animation pulse 2s infinite linear
 </style>

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -5,13 +5,16 @@
         <i class="material-icons">search</i>
         <input placeholder="Filter components" @input="filterInstances">
       </div>
-      <a 
-        class="select-component" 
+      <a
+        class="button select-component"
         :class="{active: selecting}"
         v-tooltip="'Select component from DOM tree'"
         @click="toggleSelecting"
       >
-        <i class="material-icons">location_searching</i>
+        <i class="material-icons">
+          {{ selecting ? 'gps_fixed' : 'gps_not_fixed' }}
+        </i>
+        <span>Select</span>
       </a>
       <a class="button classify-names"
          :class="{ active: classifyComponents }"
@@ -19,6 +22,7 @@
          @click="toggleClassifyComponents"
       >
         <i class="material-icons">text_fields</i>
+        <span>Formatting</span>
       </a>
     </action-header>
     <div slot="scroll" class="tree">
@@ -45,24 +49,41 @@ import keyNavMixin from '../../mixins/key-nav'
 
 export default {
   mixins: [keyNavMixin],
+
   components: {
     ScrollPane,
     ActionHeader,
     ComponentInstance
   },
+
   props: {
     instances: Array
   },
+
   data () {
     return {
       selecting: false
     }
   },
+
   computed: {
     ...mapState('components', [
       'classifyComponents'
     ])
   },
+
+  mounted () {
+    bridge.on('component-selected', () => {
+      this.selecting = false
+    })
+  },
+
+  beforeDestroy () {
+    if (this.selecting) {
+      bridge.send('stop-component-selector')
+    }
+  },
+
   methods: {
     ...mapActions('components', [
       'toggleClassifyComponents'
@@ -101,6 +122,7 @@ export default {
         findByIndex(all, currentIndex + 1).select()
       }
     },
+
     toggleSelecting () {
       this.selecting = !this.selecting
 
@@ -110,11 +132,6 @@ export default {
         bridge.send('stop-component-selector')
       }
     }
-  },
-  mounted () {
-    bridge.on('component-selected', () => {
-      this.selecting = false
-    })
   }
 }
 

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -8,7 +8,7 @@
       <a
         class="button select-component"
         :class="{active: selecting}"
-        v-tooltip="'Select component in the page'"
+        v-tooltip="selectTooltip"
         @click="setSelecting(!selecting)"
       >
         <i class="material-icons">
@@ -44,11 +44,11 @@ import ScrollPane from 'components/ScrollPane.vue'
 import ActionHeader from 'components/ActionHeader.vue'
 import ComponentInstance from './ComponentInstance.vue'
 
-import { classify } from '../../../util'
-import keyNavMixin from '../../mixins/key-nav'
+import { classify } from 'src/util'
+import Keyboard, { UP, DOWN, LEFT, RIGHT, S } from '../../mixins/keyboard'
 
 export default {
-  mixins: [keyNavMixin],
+  mixins: [Keyboard],
 
   components: {
     ScrollPane,
@@ -69,7 +69,11 @@ export default {
   computed: {
     ...mapState('components', [
       'classifyComponents'
-    ])
+    ]),
+
+    selectTooltip () {
+      return '<span class="keyboard">S</span> Select component in the page'
+    }
   },
 
   mounted () {
@@ -91,43 +95,49 @@ export default {
       bridge.send('filter-instances', classify(e.target.value))
     },
 
-    onKeyNav (dir) {
-      const all = getAllInstances(this.$refs.instances)
-      if (!all.length) {
-        return
-      }
-
-      const { current, currentIndex } = findCurrent(all, i => i.selected)
-      if (!current) {
-        return
-      }
-
-      if (dir === 'left') {
-        if (current.expanded) {
-          current.collapse()
-        } else if (current.$parent && current.$parent.expanded) {
-          current.$parent.select()
+    onKeyUp ({ keyCode }) {
+      if ([LEFT, RIGHT, UP, DOWN].includes(keyCode)) {
+        const all = getAllInstances(this.$refs.instances)
+        if (!all.length) {
+          return
         }
-      } else if (dir === 'right') {
-        if (current.expanded && current.$children.length) {
+
+        const { current, currentIndex } = findCurrent(all, i => i.selected)
+        if (!current) {
+          return
+        }
+
+        if (keyCode === LEFT) {
+          if (current.expanded) {
+            current.collapse()
+          } else if (current.$parent && current.$parent.expanded) {
+            current.$parent.select()
+          }
+        } else if (keyCode === RIGHT) {
+          if (current.expanded && current.$children.length) {
+            findByIndex(all, currentIndex + 1).select()
+          } else {
+            current.expand()
+          }
+        } else if (keyCode === UP) {
+          findByIndex(all, currentIndex - 1).select()
+        } else if (keyCode === DOWN) {
           findByIndex(all, currentIndex + 1).select()
-        } else {
-          current.expand()
         }
-      } else if (dir === 'up') {
-        findByIndex(all, currentIndex - 1).select()
-      } else {
-        findByIndex(all, currentIndex + 1).select()
+      } else if (keyCode === S) {
+        this.setSelecting(!this.selecting)
       }
     },
 
     setSelecting (value) {
-      this.selecting = value
+      if (this.selecting !== value) {
+        this.selecting = value
 
-      if (this.selecting) {
-        bridge.send('start-component-selector')
-      } else {
-        bridge.send('stop-component-selector')
+        if (this.selecting) {
+          bridge.send('start-component-selector')
+        } else {
+          bridge.send('stop-component-selector')
+        }
       }
     }
   }

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -8,7 +8,7 @@
       <a 
         class="select-component" 
         :class="{active: selecting}"
-        v-tooltip="'Select component from dom'"
+        v-tooltip="'Select component from DOM tree'"
         @click="toggleSelecting"
       >
         <i class="material-icons">location_searching</i>

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -9,7 +9,7 @@
         class="button select-component"
         :class="{active: selecting}"
         v-tooltip="'Select component in the page'"
-        @click="toggleSelecting"
+        @click="setSelecting(!selecting)"
       >
         <i class="material-icons">
           {{ selecting ? 'gps_fixed' : 'gps_not_fixed' }}
@@ -73,15 +73,13 @@ export default {
   },
 
   mounted () {
-    bridge.on('component-selected', () => {
-      this.selecting = false
+    bridge.on('instance-details', () => {
+      this.setSelecting(false)
     })
   },
 
   beforeDestroy () {
-    if (this.selecting) {
-      bridge.send('stop-component-selector')
-    }
+    this.setSelecting(false)
   },
 
   methods: {
@@ -123,8 +121,8 @@ export default {
       }
     },
 
-    toggleSelecting () {
-      this.selecting = !this.selecting
+    setSelecting (value) {
+      this.selecting = value
 
       if (this.selecting) {
         bridge.send('start-component-selector')

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -5,6 +5,14 @@
         <i class="material-icons">search</i>
         <input placeholder="Filter components" @input="filterInstances">
       </div>
+      <a 
+        class="select-component" 
+        :class="{active: selecting}"
+        v-tooltip="'Select component from dom'"
+        @click="toggleSelecting"
+      >
+        <i class="material-icons">location_searching</i>
+      </a>
       <a class="button classify-names"
          :class="{ active: classifyComponents }"
          v-tooltip="'Format component names'"
@@ -44,6 +52,11 @@ export default {
   },
   props: {
     instances: Array
+  },
+  data () {
+    return {
+      selecting: false
+    }
   },
   computed: {
     ...mapState('components', [
@@ -87,7 +100,19 @@ export default {
       } else {
         findByIndex(all, currentIndex + 1).select()
       }
+    },
+    toggleSelecting () {
+      this.selecting = !this.selecting
+
+      if (this.selecting) {
+        bridge.send('start-component-selector')
+      } else {
+        bridge.send('stop-component-selector')
+      }
     }
+  },
+  mounted () {
+    bridge.on('component-selected', () => this.selecting = false)
   }
 }
 
@@ -124,6 +149,16 @@ function findByIndex (all, index) {
 </script>
 
 <style lang="stylus">
+@import "../../variables"
+
+
 .tree
   padding 5px
+.select-component
+  display flex
+  align-items center
+  cursor pointer
+  &.active
+    color $active-color
+
 </style>

--- a/src/devtools/views/vuex/VuexHistory.vue
+++ b/src/devtools/views/vuex/VuexHistory.vue
@@ -76,11 +76,11 @@
 import ScrollPane from 'components/ScrollPane.vue'
 import ActionHeader from 'components/ActionHeader.vue'
 
-import keyNavMixin from '../../mixins/key-nav'
+import Keyboard, { UP, DOWN } from '../../mixins/keyboard'
 import { mapState, mapGetters, mapActions } from 'vuex'
 
 export default {
-  mixins: [keyNavMixin],
+  mixins: [Keyboard],
   components: {
     ActionHeader,
     ScrollPane
@@ -124,10 +124,10 @@ export default {
     isInspected (entry) {
       return this.inspectedIndex === this.history.indexOf(entry)
     },
-    onKeyNav (dir) {
-      if (dir === 'up') {
+    onKeyUp ({ keyCode }) {
+      if (keyCode === UP) {
         this.inspect(this.inspectedIndex - 1)
-      } else if (dir === 'down') {
+      } else if (keyCode === DOWN) {
         this.inspect(this.inspectedIndex + 1)
       }
     }

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -72,6 +72,16 @@ module.exports = {
       .setValue('.search input', 'target')
       .assert.count('.instance', 5)
 
+      // Select component
+      .click('.select-component')
+      .frame('target')
+        .useXpath()
+        .moveToElement("//*[contains(text(), 'mine')]", 0, 0)
+        .click('//*[contains(text(), "mine")]')
+        .frame(null)
+      .useCss()
+      .assert.containsText('.tree', '<Mine> == $vm0')
+
       // vuex
       .frame('target')
         .click('.increment')

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -1,4 +1,8 @@
 module.exports = {
+  beforeEach (browser, done) {
+    browser.resizeWindow(1280, 800, done)
+  },
+
   'vue-devtools e2e tests': function (browser) {
     var baseInstanceCount = 8
 

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -38,7 +38,7 @@ module.exports = {
       .assert.containsText('.data-el.props .data-field:nth-child(2)', 'msg:"hi"')
       .assert.containsText('.data-el.props .data-field:nth-child(3)', 'obj:undefined')
       // Regexp
-      .assert.containsText('.data-el.data .data-field:nth-child(7)', 'regex:/(a\\w+b)/g')
+      .assert.containsText('.data-el.data .data-field:nth-child(8)', 'regex:/(a\\w+b)/g')
       // Literals
       .assert.containsText('.data-el.data .data-field:nth-child(5)', 'NaN')
       .assert.containsText('.data-el.data .data-field:nth-child(2)', 'Infinity')
@@ -75,9 +75,8 @@ module.exports = {
       // Select component
       .click('.select-component')
       .frame('target')
-        .useXpath()
-        .moveToElement("//*[contains(text(), 'mine')]", 0, 0)
-        .click('//*[contains(text(), "mine")]')
+        .moveToElement('.mine', 0, 0)
+        .click('.mine')
         .frame(null)
       .useCss()
       .assert.containsText('.tree', `<Mine>`)

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -80,7 +80,8 @@ module.exports = {
         .click('//*[contains(text(), "mine")]')
         .frame(null)
       .useCss()
-      .assert.containsText('.tree', '<Mine> == $vm0')
+      .assert.containsText('.tree', `<Mine>`)
+      .assert.containsText('.right.bottom .action-header', `Mine`)
 
       // vuex
       .frame('target')


### PR DESCRIPTION
Inspired by the react developer tools and of course Chromes developer tools.
This PR adds functionality for selecting a component from the dom tree. 

Instead of just highlighting elements it highlights components themselves if the hovered element is not a Vue component it'll select the parent component.
The component tree will expand if the selected component is minimized.

![dec-20-2017 22-39-20](https://user-images.githubusercontent.com/947230/34230015-d1669320-e5d6-11e7-8c53-12676850ce4e.gif)

Edit:
Just saw Zzuligy's [PR](https://github.com/vuejs/vue-devtools/pull/469). 
While I think that its cool that he's using the developer tools selector I still feel that our PR's have some major differences. Eg. that my version will allow the feature to also function in Safari and Firefox. 
I've messages Zzuligy to hear how he feels.