### PR TITLE
Editable fields

### DIFF
--- a/shells/dev/target/Target.vue
+++ b/shells/dev/target/Target.vue
@@ -8,7 +8,7 @@
     <button class="add" @click="add">Add</button>
     <button class="remove" @click="rm">Remove</button>
     <input v-model="localMsg">
-    <other v-for="item in items" :key="item"></other>
+    <other v-for="item in items" :key="item" :id="item"></other>
   </div>
 </template>
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -82,8 +82,8 @@ function connect () {
 
   bridge.on('leave-instance', unHighlight)
 
-  bridge.on('set-instance-data', ({ id, path, value }) => {
-    setStateValue(id, path, value)
+  bridge.on('set-instance-data', args => {
+    setStateValue(args)
     flush()
   })
 
@@ -630,13 +630,17 @@ function getUniqueId (instance) {
   return `${rootVueId}:${instance._uid}`
 }
 
-function setStateValue (id, path, value) {
+function setStateValue ({ id, path, value, newKey, remove }) {
   const instance = instanceMap.get(id)
   if (instance) {
     try {
-      const data = parse(value)
-      set(instance._data, path, data, (obj, field, value) => {
-        instance.$set(obj, field, value)
+      let parsedValue
+      if (value) {
+        parsedValue = parse(value)
+      }
+      set(instance._data, path, parsedValue, (obj, field, value) => {
+        (remove || newKey) && instance.$delete(obj, field)
+        !remove && instance.$set(obj, newKey || field, value)
       })
     } catch (e) {
       console.error(e)

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -4,7 +4,7 @@
 import { highlight, unHighlight, getInstanceRect } from './highlighter'
 import { initVuexBackend } from './vuex'
 import { initEventsBackend } from './events'
-import { stringify, classify, camelize, isEditable, set, parse } from '../util'
+import { stringify, classify, camelize, set, parse } from '../util'
 import path from 'path'
 
 // Use a custom basename functions instead of the shimed version
@@ -447,7 +447,7 @@ function processState (instance) {
     .map(key => ({
       key,
       value: instance._data[key],
-      editable: isEditable(instance._data[key])
+      editable: true
     }))
 }
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -635,7 +635,9 @@ function setStateValue (id, path, value) {
   if (instance) {
     try {
       const data = parse(value)
-      set(instance._data, path, data)
+      set(instance._data, path, data, (obj, field, value) => {
+        instance.$set(obj, field, value)
+      })
     } catch (e) {
       console.error(e)
     }

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -636,7 +636,7 @@ function setStateValue ({ id, path, value, newKey, remove }) {
     try {
       let parsedValue
       if (value) {
-        parsedValue = parse(value)
+        parsedValue = parse(value, true)
       }
       set(instance._data, path, parsedValue, (obj, field, value) => {
         (remove || newKey) && instance.$delete(obj, field)

--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -3,7 +3,7 @@
 <template>
 <div id="app" :class="{ app: true, dark: isDark }">
   <datalist id="special-tokens">
-    <option v-for="(value, key) of specialTokens" :key="key" :value="value | specialTokenValue"></option>
+    <option v-for="(value, key) of specialTokens" :key="key" :value="key"></option>
   </datalist>
   <div class="header">
     <img class="logo" src="./assets/logo.png" alt="Vue">
@@ -113,9 +113,6 @@ export default {
     tab () {
       this.$nextTick(this.updateActiveBar)
     }
-  },
-  filters: {
-    specialTokenValue: value => JSON.stringify(value)
   }
 }
 </script>

--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -2,6 +2,9 @@
 
 <template>
 <div id="app" :class="{ app: true, dark: isDark }">
+  <datalist id="special-tokens">
+    <option v-for="(value, key) of specialTokens" :key="key" :value="value | specialTokenValue"></option>
+  </datalist>
   <div class="header">
     <img class="logo" src="./assets/logo.png" alt="Vue">
     <span class="message-container">
@@ -47,6 +50,7 @@
 import ComponentsTab from './views/components/ComponentsTab.vue'
 import EventsTab from './views/events/EventsTab.vue'
 import VuexTab from './views/vuex/VuexTab.vue'
+import { SPECIAL_TOKENS } from '../util'
 
 import { mapState } from 'vuex'
 
@@ -64,11 +68,16 @@ export default {
     vuex: VuexTab,
     events: EventsTab
   },
-  computed: mapState({
-    message: state => state.message,
-    tab: state => state.tab,
-    newEventCount: state => state.events.newEventCount
-  }),
+  computed: {
+    ...mapState({
+      message: state => state.message,
+      tab: state => state.tab,
+      newEventCount: state => state.events.newEventCount
+    }),
+    specialTokens () {
+      return SPECIAL_TOKENS
+    }
+  },
   methods: {
     switchTab (tab) {
       bridge.send('switch-tab', tab)
@@ -104,6 +113,9 @@ export default {
     tab () {
       this.$nextTick(this.updateActiveBar)
     }
+  },
+  filters: {
+    specialTokenValue: value => JSON.stringify(value)
   }
 }
 </script>

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -15,6 +15,7 @@
         <input
           ref="keyInput"
           class="edit-input key-input"
+          :class="{ error: !keyValid }"
           v-model="editedKey"
           @keyup.esc="cancelEdit()"
           @keyup.enter="submitEdit()"
@@ -34,6 +35,7 @@
         <input
           ref="editInput"
           class="edit-input value-input"
+          :class="{ error: !valueValid }"
           v-model="editedValue"
           list="special-tokens"
           @keyup.esc="cancelEdit()"
@@ -596,6 +598,8 @@ export default {
   border-radius 3px
   padding 2px
   outline none
+  &.error
+    border-color $orange
 .value-input
   width 180px
 .key-input

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -57,6 +57,12 @@
             title="Edit value"
             @click="openEdit"
           >edit</i>
+          <i
+            v-if="quickEditInfo"
+            class="icon-button quick-edit material-icons"
+            title="Quick edit"
+            @click="quickEdit"
+          >{{ quickEditInfo.icon }}</i>
         </span>
       </template>
     </div>
@@ -219,6 +225,19 @@ export default {
       } catch (e) {
         return false
       }
+    },
+    quickEditInfo () {
+      if (this.isEditable) {
+        const value = this.field.value
+        const type = typeof value
+        if (type === 'boolean') {
+          return {
+            icon: value ? 'check_box' : 'check_box_outline_blank',
+            newValue: !value
+          }
+        }
+      }
+      return null
     }
   },
   methods: {
@@ -251,12 +270,15 @@ export default {
       if (this.editValid) {
         this.editing = false
         const value = this.transformSpecialTokens(this.editedValue, false)
-        bridge.send('set-instance-data', {
-          id: this.inspectedInstance.id,
-          path: this.path,
-          value
-        })
+        this.sendEdit(value)
       }
+    },
+    sendEdit (value) {
+      bridge.send('set-instance-data', {
+        id: this.inspectedInstance.id,
+        path: this.path,
+        value
+      })
     },
     transformSpecialTokens (str, display) {
       Object.keys(SPECIAL_TOKENS).forEach(key => {
@@ -273,6 +295,11 @@ export default {
         str = str.replace(new RegExp(search), replace)
       })
       return str
+    },
+    quickEdit () {
+      if (this.quickEditInfo) {
+        this.sendEdit(this.quickEditInfo.newValue)
+      }
     }
   }
 }

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -195,7 +195,7 @@ export default {
     },
     editValid () {
       try {
-        this.editedValue && parse(this.editedValue)
+        parse(this.editedValue)
         return true
       } catch (e) {
         return false

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -23,6 +23,7 @@
           ref="editInput"
           class="edit-input"
           v-model="editedValue"
+          list="special-tokens"
           @keyup.esc="cancelEdit"
           @keyup.enter="submitEdit"
         >

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="data-field">
+  <div class="data-field" :class="cssClass">
     <div class="self"
       @click="toggle"
       :style="{ marginLeft: depth * 14 + 'px' }">
@@ -15,15 +15,57 @@
           <span class="value">{{ val }}</span>
         </div>
       </div></span>
-      <span class="value" :class="valueType">{{ formattedValue }}</span>
+      <span
+        v-if="editing"
+        class="edit-overlay"
+      >
+        <input
+          ref="editInput"
+          class="edit-input"
+          v-model="editedValue"
+          @keyup.esc="cancelEdit"
+          @keyup.enter="submitEdit"
+        >
+        <span class="actions">
+          <i
+            v-if="!editValid"
+            class="icon-button material-icons warning"
+            title="Invalid value"
+          >warning</i>
+          <template v-else>
+            <i
+              class="icon-button material-icons"
+              title="[Esc] Cancel"
+              @click="cancelEdit"
+            >close</i>
+            <i
+              class="icon-button material-icons"
+              title="[Enter] Submit change"
+              @click="submitEdit"
+            >done</i>
+          </template>
+        </span>
+      </span>
+      <template v-else>
+        <span class="value" :class="valueType">{{ formattedValue }}</span>
+        <span class="actions">
+          <i
+            v-if="field.editable"
+            class="icon-button edit-value material-icons"
+            title="Edit value"
+            @click="openEdit"
+          >edit</i>
+        </span>
+      </template>
     </div>
     <div class="children" v-if="expanded && isExpandableType">
       <data-field
         v-for="subField in limitedSubFields"
         :key="subField.key"
         :field="subField"
-        :depth="depth + 1">
-      </data-field>
+        :depth="depth + 1"
+        :path="`${path}.${subField.key}`"
+      />
       <span class="more"
         v-if="formattedSubFields.length > limit"
         @click="limit += 10"
@@ -35,16 +77,20 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import {
   UNDEFINED,
   INFINITY,
   NAN,
   isPlainObject,
-  sortByKey
+  sortByKey,
+  parse
 } from 'src/util'
 
 const rawTypeRE = /^\[object (\w+)]$/
 const specialTypeRE = /^\[native \w+ (.*)\]$/
+
+let currentEditedField = null
 
 function subFieldCount (value) {
   if (Array.isArray(value)) {
@@ -60,15 +106,26 @@ export default {
   name: 'DataField',
   props: {
     field: Object,
-    depth: Number
+    depth: Number,
+    path: String
   },
   data () {
     return {
       limit: Array.isArray(this.field.value) ? 10 : Infinity,
-      expanded: this.depth === 0 && this.field.key !== '$route' && (subFieldCount(this.field.value) < 5)
+      expanded: this.depth === 0 && this.field.key !== '$route' && (subFieldCount(this.field.value) < 5),
+      editing: false,
+      editedValue: null
     }
   },
   computed: {
+    ...mapState('components', [
+      'inspectedInstance'
+    ]),
+    cssClass () {
+      return {
+        editing: this.editing
+      }
+    },
     valueType () {
       const value = this.field.value
       const type = typeof value
@@ -135,6 +192,14 @@ export default {
     },
     limitedSubFields () {
       return this.formattedSubFields.slice(0, this.limit)
+    },
+    editValid () {
+      try {
+        this.editedValue && parse(this.editedValue)
+        return true
+      } catch (e) {
+        return false
+      }
     }
   },
   methods: {
@@ -143,7 +208,33 @@ export default {
         this.expanded = !this.expanded
       }
     },
-    hyphen: v => v.replace(/\s/g, '-')
+    hyphen: v => v.replace(/\s/g, '-'),
+    openEdit () {
+      if (currentEditedField && currentEditedField !== this) {
+        currentEditedField.cancelEdit()
+      }
+      this.editedValue = JSON.stringify(this.field.value)
+      this.editing = true
+      currentEditedField = this
+      this.$nextTick(() => {
+        const el = this.$refs.editInput
+        el.focus()
+        el.setSelectionRange(0, el.value.length)
+      })
+    },
+    cancelEdit () {
+      this.editing = false
+    },
+    submitEdit () {
+      if (this.editValid) {
+        this.editing = false
+        bridge.send('set-instance-data', {
+          id: this.inspectedInstance.id,
+          path: this.path,
+          value: this.editedValue
+        })
+      }
+    }
   }
 }
 </script>
@@ -173,6 +264,23 @@ export default {
     transition transform .1s ease
     &.rotated
       transform rotate(90deg)
+  .actions
+    visibility hidden
+    margin-left 6px
+    display inline-flex
+    align-items center
+    position relative
+    top -1px
+    .icon-button
+      font-size 14px
+      &:not(:last-child)
+        margin-right 4px
+    .warning
+      color $orange
+  &:hover,
+  .editing &
+    .actions
+      visibility visible
   .key
     color #881391
   .colon
@@ -257,4 +365,11 @@ export default {
   padding 0 4px 4px
   &:hover
     background-color #eee
+
+.edit-input
+  font-family Menlo, Consolas, monospace
+  border solid 1px $green
+  border-radius 3px
+  padding 2px
+  outline none
 </style>

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -382,4 +382,5 @@ export default {
   border-radius 3px
   padding 2px
   outline none
+  width 200px
 </style>

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -49,7 +49,10 @@
         </span>
       </span>
       <template v-else>
-        <span class="value" :class="valueType">{{ formattedValue }}</span>
+        <span
+          class="value"
+          :class="[valueType, `raw-${rawValueType}`]"
+        >{{ formattedValue }}</span>
         <span class="actions">
           <i
             v-if="isEditable"
@@ -158,6 +161,9 @@ export default {
       } else if (isPlainObject(value)) {
         return 'plain-object'
       }
+    },
+    rawValueType () {
+      return typeof this.field.value
     },
     isExpandableType () {
       const value = this.field.value
@@ -338,6 +344,7 @@ export default {
     position relative
     top -1px
     .icon-button
+      user-select none
       font-size 14px
       &:not(:last-child)
         margin-right 4px
@@ -353,6 +360,7 @@ export default {
     margin-right .5em
     position relative
   .value
+    display inline-block
     color #444
     &.string, &.native
       color #c41a16
@@ -360,6 +368,8 @@ export default {
       color #999
     &.literal
       color #0033cc
+    &.raw-boolean
+      width 36px
 
   .type
     color $background-color

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -60,12 +60,15 @@
             title="Edit value"
             @click="openEdit"
           >edit</i>
-          <i
-            v-if="quickEditInfo"
-            class="icon-button quick-edit material-icons"
-            title="Quick edit"
-            @click="quickEdit"
-          >{{ quickEditInfo.icon }}</i>
+          <template v-if="quickEdits">
+            <i
+              v-for="(info, index) of quickEdits"
+              :key="index"
+              class="icon-button quick-edit material-icons"
+              title="Quick edit"
+              @click="quickEdit(info)"
+            >{{ info.icon }}</i>
+          </template>
         </span>
       </template>
     </div>
@@ -232,15 +235,17 @@ export default {
         return false
       }
     },
-    quickEditInfo () {
+    quickEdits () {
       if (this.isEditable) {
         const value = this.field.value
         const type = typeof value
         if (type === 'boolean') {
-          return {
-            icon: value ? 'check_box' : 'check_box_outline_blank',
-            newValue: !value
-          }
+          return [
+            {
+              icon: value ? 'check_box' : 'check_box_outline_blank',
+              newValue: !value
+            }
+          ]
         }
       }
       return null
@@ -302,10 +307,8 @@ export default {
       })
       return str
     },
-    quickEdit () {
-      if (this.quickEditInfo) {
-        this.sendEdit(this.quickEditInfo.newValue)
-      }
+    quickEdit (info) {
+      this.sendEdit(info.newValue)
     }
   }
 }

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -246,6 +246,17 @@ export default {
               newValue: !value
             }
           ]
+        } else if (type === 'number') {
+          return [
+            {
+              icon: 'remove',
+              newValue: value - 1
+            },
+            {
+              icon: 'add',
+              newValue: value + 1
+            }
+          ]
         }
       }
       return null

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -50,7 +50,7 @@
         <span class="value" :class="valueType">{{ formattedValue }}</span>
         <span class="actions">
           <i
-            v-if="field.editable"
+            v-if="isEditable"
             class="icon-button edit-value material-icons"
             title="Edit value"
             @click="openEdit"
@@ -65,6 +65,7 @@
         :field="subField"
         :depth="depth + 1"
         :path="`${path}.${subField.key}`"
+        :editable="editable"
       />
       <span class="more"
         v-if="formattedSubFields.length > limit"
@@ -107,7 +108,8 @@ export default {
   props: {
     field: Object,
     depth: Number,
-    path: String
+    path: String,
+    editable: Boolean
   },
   data () {
     return {
@@ -147,6 +149,14 @@ export default {
     isExpandableType () {
       const value = this.field.value
       return Array.isArray(value) || isPlainObject(value)
+    },
+    isEditable () {
+      const type = this.valueType
+      return this.editable && (
+        type === 'null' ||
+        type === 'literal' ||
+        type === 'string'
+      )
     },
     formattedValue () {
       const value = this.field.value

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -56,7 +56,7 @@
         <span class="actions">
           <i
             v-if="isEditable"
-            class="icon-button edit-value material-icons"
+            class="edit-value icon-button material-icons"
             title="Edit value"
             @click="openEdit"
           >edit</i>
@@ -64,11 +64,17 @@
             <i
               v-for="(info, index) of quickEdits"
               :key="index"
-              class="icon-button quick-edit material-icons"
+              class="quick-edit icon-button material-icons"
               :title="info.title || 'Quick edit'"
               @click="quickEdit(info, $event)"
             >{{ info.icon }}</i>
           </template>
+          <i
+            v-if="removable"
+            class="remove-field icon-button material-icons"
+            title="Remove value"
+            @click="removeField"
+          >delete</i>
         </span>
       </template>
     </div>
@@ -80,6 +86,8 @@
         :depth="depth + 1"
         :path="`${path}.${subField.key}`"
         :editable="editable"
+        :removable="valueType === 'array' || valueType === 'plain-object'"
+        @remove-field="onRemoveField(subField)"
       />
       <span class="more"
         v-if="formattedSubFields.length > limit"
@@ -148,7 +156,11 @@ export default {
     field: Object,
     depth: Number,
     path: String,
-    editable: Boolean
+    editable: Boolean,
+    removable: {
+      type: Boolean,
+      default: false
+    }
   },
   data () {
     return {
@@ -351,7 +363,19 @@ export default {
       } else {
         newValue = info.newValue
       }
-      this.sendEdit(newValue)
+      this.sendEdit(JSON.stringify(newValue))
+    },
+    removeField () {
+      this.$emit('remove-field')
+    },
+    onRemoveField (subField) {
+      const newValue = this.field.value
+      if (this.valueType === 'array') {
+        newValue.splice(subField.key, 1)
+      } else if (this.valueType === 'plain-object') {
+        delete newValue[subField.key]
+      }
+      this.sendEdit(JSON.stringify(newValue))
     }
   }
 }
@@ -495,4 +519,7 @@ export default {
   padding 2px
   outline none
   width 200px
+
+.remove-field
+  margin-left 10px
 </style>

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="data-field" :class="cssClass">
+  <div class="data-field">
     <div class="self"
+      :class="cssClass"
       @click="toggle"
       :style="{ marginLeft: depth * 14 + 'px' }">
       <span
@@ -298,7 +299,7 @@ export default {
     .warning
       color $orange
   &:hover,
-  .editing &
+  &.editing
     .actions
       visibility visible
   .key

--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -145,6 +145,10 @@ export default {
         return 'native'
       } else if (type === 'string' && !rawTypeRE.test(value)) {
         return 'string'
+      } else if (Array.isArray(value)) {
+        return 'array'
+      } else if (isPlainObject(value)) {
+        return 'plain-object'
       }
     },
     isExpandableType () {
@@ -156,7 +160,9 @@ export default {
       return this.editable && (
         type === 'null' ||
         type === 'literal' ||
-        type === 'string'
+        type === 'string' ||
+        type === 'array' ||
+        type === 'plain-object'
       )
     },
     formattedValue () {
@@ -169,9 +175,9 @@ export default {
         return 'NaN'
       } else if (value === INFINITY) {
         return 'Infinity'
-      } else if (Array.isArray(value)) {
+      } else if (this.valueType === 'array') {
         return 'Array[' + value.length + ']'
-      } else if (isPlainObject(value)) {
+      } else if (this.valueType === 'plain-object') {
         return 'Object' + (Object.keys(value).length ? '' : ' (empty)')
       } else if (this.valueType === 'native') {
         return specialTypeRE.exec(value)[1]
@@ -214,7 +220,10 @@ export default {
     }
   },
   methods: {
-    toggle () {
+    toggle (event) {
+      if (event.target.tagName === 'INPUT' || event.target.className.includes('button')) {
+        return
+      }
       if (this.isExpandableType) {
         this.expanded = !this.expanded
       }

--- a/src/devtools/components/StateInspector.vue
+++ b/src/devtools/components/StateInspector.vue
@@ -9,7 +9,8 @@
             :key="field.key"
             :field="field"
             :depth="0"
-            :path="field.key">
+            :path="field.key"
+            :editable="field.editable">
           </data-field>
         </template>
         <template v-else>
@@ -18,7 +19,8 @@
             :key="key"
             :field="{ value, key }"
             :depth="0"
-            :path="key">
+            :path="key"
+            :editable="false">
           </data-field>
         </template>
       </div>

--- a/src/devtools/components/StateInspector.vue
+++ b/src/devtools/components/StateInspector.vue
@@ -8,7 +8,8 @@
             v-for="field in state[type]"
             :key="field.key"
             :field="field"
-            :depth="0">
+            :depth="0"
+            :path="field.key">
           </data-field>
         </template>
         <template v-else>
@@ -16,7 +17,8 @@
             v-for="(value, key) in state[type]"
             :key="key"
             :field="{ value, key }"
-            :depth="0">
+            :depth="0"
+            :path="key">
           </data-field>
         </template>
       </div>

--- a/src/devtools/mixins/key-nav.js
+++ b/src/devtools/mixins/key-nav.js
@@ -8,6 +8,9 @@ const navMap = {
 const activeInstances = []
 
 document.addEventListener('keyup', e => {
+  if (e.target.tagName === 'INPUT') {
+    return
+  }
   if (navMap[e.keyCode]) {
     activeInstances.forEach(vm => {
       if (vm.onKeyNav) {

--- a/src/devtools/variables.styl
+++ b/src/devtools/variables.styl
@@ -5,6 +5,7 @@ $green = #42B983
 $darkerGreen = #3BA776
 $slate = #242424
 $white = #FFFFFF
+$orange = #DB6B00
 
 // The min-width to give icons text...
 $wide = 820px

--- a/src/util.js
+++ b/src/util.js
@@ -40,6 +40,8 @@ export const INFINITY = '__vue_devtool_infinity__'
 export const NAN = '__vue_devtool_nan__'
 
 export const SPECIAL_TOKENS = {
+  'true': true,
+  'false': false,
   'undefined': UNDEFINED,
   'null': null,
   'Infinity': INFINITY,

--- a/src/util.js
+++ b/src/util.js
@@ -39,6 +39,12 @@ export const UNDEFINED = '__vue_devtool_undefined__'
 export const INFINITY = '__vue_devtool_infinity__'
 export const NAN = '__vue_devtool_nan__'
 
+export const SPECIAL_TOKENS = {
+  UNDEFINED,
+  INFINITY,
+  NAN
+}
+
 export function stringify (data) {
   return CircularJSON.stringify(data, replacer)
 }

--- a/src/util.js
+++ b/src/util.js
@@ -40,9 +40,10 @@ export const INFINITY = '__vue_devtool_infinity__'
 export const NAN = '__vue_devtool_nan__'
 
 export const SPECIAL_TOKENS = {
-  UNDEFINED,
-  INFINITY,
-  NAN
+  'undefined': UNDEFINED,
+  'null': null,
+  'Infinity': INFINITY,
+  'NaN': NAN
 }
 
 export function stringify (data) {

--- a/src/util.js
+++ b/src/util.js
@@ -164,20 +164,6 @@ export function sortByKey (state) {
   })
 }
 
-export function isEditable (value) {
-  const type = typeof value
-  return (
-    value === null ||
-    type === 'undefined' ||
-    type === 'string' ||
-    type === 'number' ||
-    type === 'boolean'/* ||
-    value instanceof RegExp ||
-    value instanceof Date */
-    // Need Date type PR merged #474
-  )
-}
-
 export function set (object, path, value) {
   const sections = path.split('.')
   while (sections.length > 1) {

--- a/src/util.js
+++ b/src/util.js
@@ -163,3 +163,25 @@ export function sortByKey (state) {
     return 0
   })
 }
+
+export function isEditable (value) {
+  const type = typeof value
+  return (
+    value === null ||
+    type === 'undefined' ||
+    type === 'string' ||
+    type === 'number' ||
+    type === 'boolean'/* ||
+    value instanceof RegExp ||
+    value instanceof Date */
+    // Need Date type PR merged #474
+  )
+}
+
+export function set (object, path, value) {
+  const sections = path.split('.')
+  while (sections.length > 1) {
+    object = object[sections.shift()]
+  }
+  object[sections[0]] = value
+}

--- a/src/util.js
+++ b/src/util.js
@@ -170,10 +170,15 @@ export function sortByKey (state) {
   })
 }
 
-export function set (object, path, value) {
+export function set (object, path, value, cb = null) {
   const sections = path.split('.')
   while (sections.length > 1) {
     object = object[sections.shift()]
   }
-  object[sections[0]] = value
+  const field = sections[0]
+  if (cb) {
+    cb(object, field, value)
+  } else {
+    object[field] = value
+  }
 }


### PR DESCRIPTION
Fix #74

- [x] Some fields of component local state are editable
- [x] Warning if JSON is invalid
- [x] Edit values inside arrays and objects
- [x] Add items in arrays and objects
- [x] Remove items in arrays and objects
- [x] Edit the full array or object
- [x] Autocomplete special values (maybe they can be formatted with a contenteditable instead of an input)
- [x] Quick Edit for booleans: toggle `true`/`false`
- [x] Quick Edit for numbers: +1/-1 (with keyboard modifiers)

More types (RegExp + Dates) can be enabled after #474 is merged

![vue-devtools-edit](https://user-images.githubusercontent.com/2798204/34366881-8c3a366e-eaa2-11e7-9d72-7ccb8b0bbc41.png)

![vue-devtools-edit2](https://user-images.githubusercontent.com/2798204/34366882-8d668ee8-eaa2-11e7-8cb8-dd092e5d557f.png)

![vue-devtools-edit3](https://user-images.githubusercontent.com/2798204/34366884-90ba6628-eaa2-11e7-93ff-a38f73c1b7db.png)
