### PR TITLE
[docs] Typo in 'openInEditor' argument

### DIFF
--- a/docs/open-in-editor.md
+++ b/docs/open-in-editor.md
@@ -27,9 +27,7 @@ devServer: {
 3. The editor to launch is guessed. You can also specify the editor app with the `editor` option. See the [supported editors list](https://github.com/yyx990803/launch-editor#supported-editors).
 
 ```js
-openInEditor({
-  editor: 'code'
-})
+openInEditor('code')
 ```
 
 4. You can now click on the name of the component in the Component inspector pane (if the devtools knows about its file source, a tooltip will appear).


### PR DESCRIPTION
Hi!
In `docs/open-in-editor.md`, `openInEditor` function receives the argument as object `{ editor: 'code' }`.
It looks like a typo, because `launch-editor` should get string as name of the editor.
Also, it causes an error:

```
TypeError: s.match is not a function
    at parse (/Users/c01nd01r/Projects/vue-test-prj/node_modules/shell-quote/index.js:57:26)
    at Object.exports.parse (/Users/c01nd01r/Projects/vue-test-prj/node_modules/shell-quote/index.js:37:18)
    at guessEditor (/Users/c01nd01r/Projects/vue-test-prj/node_modules/launch-editor/guess.js:14:23)
...
```