### PR TITLE
VTooltip/VPopover config tweaks

### DIFF
--- a/src/devtools/plugins.js
+++ b/src/devtools/plugins.js
@@ -6,5 +6,9 @@ Vue.use(VTooltip, {
     show: 600,
     hide: 0
   },
-  defaultOffset: 2
+  defaultOffset: 2,
+  defaultBoundariesElement: document.body,
+  popover: {
+    defaultHandleResize: false
+  }
 })


### PR DESCRIPTION
Disable autoresize by default and boundaries to body (instead of scrollParent)