### PR TITLE
Dark mode color fixes

### DIFF
--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -469,6 +469,8 @@ export default {
     color: #e36eec
   &.abstract
     color $blueishGrey
+    .dark &
+      color lighten($blueishGrey, 20%)
 .value
   display inline-block
   color #444
@@ -502,6 +504,8 @@ export default {
           font-family Menlo, monospace
         .platform-windows &
           font-family Consolas, Lucida Console, Courier New, monospace
+        .dark &
+          color $purple
     &.type-component-definition
       color $green
       >>> span
@@ -513,7 +517,7 @@ export default {
     &.null
       color #999
     &.literal
-      color #997fff
+      color $purple
 
 .meta
   font-size 12px

--- a/src/devtools/variables.styl
+++ b/src/devtools/variables.styl
@@ -11,6 +11,7 @@ $orange = #DB6B00
 $red = #c41a16
 $black = #222
 $vividBlue = #0033cc
+$purple = #997fff
 
 // The min-width to give icons text...
 $wide = 1050px


### PR DESCRIPTION
- Lightened abstract keyword in State inspector (was too dark)
- Change 'f' function from blue to purple (like numbers)