### PR TITLE
Fix == $vm0

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -57,7 +57,7 @@ function connect () {
     currentInspectedId = id
     const instance = instanceMap.get(id)
     bindToConsole(instance)
-    bridge.send('instance-details', stringify(getInstanceDetails(id)))
+    flush()
   })
 
   bridge.on('scroll-to-instance', id => {


### PR DESCRIPTION
The `== $vm0` info wasn't pushed when selecting a component