### PR TITLE
Props popover improvements + v-tooltip update

### DIFF
--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -8,6 +8,11 @@
       placement="left"
       offset="24"
       :disabled="!field.meta"
+      :delay="{
+        show: 300,
+        hide: 0
+      }"
+      :open-group="'id' + _uid"
       @click.native="onClick"
     >
       <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -5547,8 +5547,8 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 v-tooltip@^2.0.0-rc.25:
-  version "2.0.0-rc.28"
-  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.0.0-rc.28.tgz#8f667433961da45117568b3d5fa40b5a251b340c"
+  version "2.0.0-rc.30"
+  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.0.0-rc.30.tgz#05749f4732ecfb86f3ece93d6c3fb636a4b3c5b1"
   dependencies:
     lodash.merge "^4.6.0"
     popper.js "^1.12.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3961,7 +3961,7 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
-popper.js@^1.12.6:
+popper.js@^1.12.9:
   version "1.12.9"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
 
@@ -5547,11 +5547,11 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 v-tooltip@^2.0.0-rc.25:
-  version "2.0.0-rc.26"
-  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.0.0-rc.26.tgz#31180d39cc267053d01ef2acdc4d0c997215d31c"
+  version "2.0.0-rc.28"
+  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.0.0-rc.28.tgz#8f667433961da45117568b3d5fa40b5a251b340c"
   dependencies:
     lodash.merge "^4.6.0"
-    popper.js "^1.12.6"
+    popper.js "^1.12.9"
     vue-resize "^0.4.3"
 
 validate-npm-package-license@^3.0.1:


### PR DESCRIPTION
- Updated v-tooltip to latest release
- Props popover:
  - Slight show delay to prevent flickering popovers with fast mouse movement
  - Exclusive open-group (only on prop popover open at a time)