### PR TITLE
New instance-selected bridge event

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -58,6 +58,7 @@ function connect () {
     const instance = instanceMap.get(id)
     bindToConsole(instance)
     flush()
+    bridge.send('instance-selected')
   })
 
   bridge.on('scroll-to-instance', id => {

--- a/src/devtools/views/components/ComponentTree.vue
+++ b/src/devtools/views/components/ComponentTree.vue
@@ -138,7 +138,7 @@ export default {
   },
 
   mounted () {
-    bridge.on('instance-details', () => {
+    bridge.on('instance-selected', () => {
       this.setSelecting(false)
     })
   },


### PR DESCRIPTION
Fix regression from #542 
The button was not turning back to normal state after a component was selected.