### PR TITLE
Fix double quotes color in Dark mode

### DIFF
--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -485,6 +485,8 @@ export default {
   &.string
     >>> span
       color $black
+      .dark &
+        color $red
   &.null
     color #999
   &.literal


### PR DESCRIPTION
In dark mode, changed strings `"` from black to red.