### PR TITLE
Update electron shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Works with [vuex](https://github.com/vuejs/vuex) for time-travel debugging:
 
 - [Get the Firefox Addon](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)
 
-- [Get standalone app](https://github.com/vuejs/vue-devtools/blob/master/shells/electron/README.md)
+- [Get standalone Electron app (works with any environment!)](https://github.com/vuejs/vue-devtools/blob/master/shells/electron/README.md)
 
 - [Workaround for Safari](https://github.com/vuejs/vue-devtools/blob/master/docs/workaround-for-safari.md)
 

--- a/shells/electron/package.json
+++ b/shells/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue/devtools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "StandAlone vue-devtools",
   "repository": {
     "url": "https://github.com/vuejs/vue-devtools.git",
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "cross-spawn": "^5.1.0",
-    "electron": "^1.7.11",
+    "electron": "1.7.11",
     "express": "^4.16.2",
     "ip": "^1.1.5",
     "socket.io": "^2.0.4"


### PR DESCRIPTION
Because of caret in version `^1.7.11` - downloaded electron was still `1.8.1`. Given official information on electron readme `Electron does not follow semantic versioning` I locked it to be exactly `1.7.11`.

I also update link copy in readme to be more explicit.