### PR TITLE
Fix initEnv, so it doesn't crash on page refresh

### DIFF
--- a/src/devtools/env.js
+++ b/src/devtools/env.js
@@ -12,6 +12,8 @@ export const keys = {
 }
 
 export function initEnv (Vue) {
+  if (Vue.prototype.hasOwnProperty('$isChrome')) return
+
   Object.defineProperties(Vue.prototype, {
     '$isChrome': { get: () => isChrome },
     '$isWindows': { get: () => isWindows },


### PR DESCRIPTION
Redefining ownProperties on Vue.prototype causes error on page refresh, as it executes `initEnv` once again. I check for presence of one of the properties assigned there so it doesn't reinitiate it when already initialized.