### PR TITLE
Add missing underscore to electron doc

### DIFF
--- a/shells/electron/README.md
+++ b/shells/electron/README.md
@@ -31,7 +31,7 @@ Then add:
 Or if you want to debug your device remotely:
 ```html
 <script>
-  window.__VUE_DEVTOOLS__HOST = '<your-local-ip>'
+  window.__VUE_DEVTOOLS_HOST__ = '<your-local-ip>'
 </script>
 <script src="http://<your-local-ip>:8098"></script>
 ```


### PR DESCRIPTION
Documentation about using the electron dev tool remotely is missing a couple of underscores after `__VUE_DEVTOOLS__HOST` 