### PR TITLE
Make ability to send vm to console slightly more obvious

### DIFF
--- a/src/devtools/locales/en.js
+++ b/src/devtools/locales/en.js
@@ -44,6 +44,11 @@ export default {
       tooltip: '[[{{keys.ctrl}}]] + [[F]] Filter components by name'
     }
   },
+  ComponentInstance: {
+    consoleId: {
+      tooltip: 'Available as <mono>{{id}}</mono> in the console.'
+    }
+  },
   ComponentInspector: {
     openInEditor: {
       tooltip: 'Open <mono><<insert_drive_file>>{{file}}</mono> in editor'

--- a/src/devtools/views/components/ComponentInstance.vue
+++ b/src/devtools/views/components/ComponentInstance.vue
@@ -23,16 +23,29 @@
         </span>
         <span class="angle-bracket">&lt;</span><span class="item-name">{{ displayName }}</span><span class="angle-bracket">&gt;</span>
       </span>
-      <span class="info console" v-if="instance.consoleId === '$vm0'" title="Available as $vm0 in the console.">
+      <span
+        v-if="instance.consoleId"
+        class="info console"
+        v-tooltip="$t('ComponentInstance.consoleId.tooltip', { id: instance.consoleId })"
+      >
         = {{ instance.consoleId }}
       </span>
-      <span class="info router-view" v-if="instance.isRouterView">
+      <span
+        v-if="instance.isRouterView"
+        class="info router-view"
+      >
         router-view{{ instance.matchedRouteSegment ? ': ' + instance.matchedRouteSegment : null }}
       </span>
-      <span class="info fragment" v-if="instance.isFragment">
+      <span
+        v-if="instance.isFragment"
+        class="info fragment"
+      >
         fragment
       </span>
-      <span class="info inactive" v-if="instance.inactive">
+      <span
+        v-if="instance.inactive"
+        class="info inactive"
+      >
         inactive
       </span>
       <span class="spacer"></span>

--- a/src/devtools/views/components/ComponentInstance.vue
+++ b/src/devtools/views/components/ComponentInstance.vue
@@ -23,7 +23,7 @@
         </span>
         <span class="angle-bracket">&lt;</span><span class="item-name">{{ displayName }}</span><span class="angle-bracket">&gt;</span>
       </span>
-      <span class="info console" v-if="instance.consoleId === '$vm0'" title="Availble as $vm0 in the console.">
+      <span class="info console" v-if="instance.consoleId === '$vm0'" title="Available as $vm0 in the console.">
         = {{ instance.consoleId }}
       </span>
       <span class="info router-view" v-if="instance.isRouterView">

--- a/src/devtools/views/components/ComponentInstance.vue
+++ b/src/devtools/views/components/ComponentInstance.vue
@@ -23,8 +23,8 @@
         </span>
         <span class="angle-bracket">&lt;</span><span class="item-name">{{ displayName }}</span><span class="angle-bracket">&gt;</span>
       </span>
-      <span class="info console" v-if="instance.consoleId === '$vm0'">
-        == {{ instance.consoleId }}
+      <span class="info console" v-if="instance.consoleId === '$vm0'" title="Availble as $vm0 in the console.">
+        = {{ instance.consoleId }}
       </span>
       <span class="info router-view" v-if="instance.isRouterView">
         router-view{{ instance.matchedRouteSegment ? ': ' + instance.matchedRouteSegment : null }}
@@ -187,7 +187,7 @@ export default {
   &.console
     color #fff
     background-color transparent
-    top 0px
+    top 0
   &.router-view
     background-color #ff8344
   &.fragment


### PR DESCRIPTION
I added a title attribute: "Available as $vm0 in the console."

Also changed `== $vm0` to `= $vm0` since it seems like something was assigned instead of just equal to something. I was also considering maybe `= window.$vm0` to make it even more clear?

Let me know what you think.