### PR TITLE
Catch exception for Function.toString on Proxies etc.

### DIFF
--- a/shells/dev/target/NativeTypes.vue
+++ b/shells/dev/target/NativeTypes.vue
@@ -44,6 +44,19 @@ function setToString (func, string) {
 
 const aWeirdFunction = setToString(function weird (a, b, c) {}, 'foo')
 
+function sum (a, b) {
+  return a + b
+}
+
+const handler = {
+  apply: function (target, thisArg, argumentsList) {
+    console.log(`Calculate sum: ${argumentsList}`)
+    return argumentsList[0] + argumentsList[1]
+  }
+}
+
+const proxy1 = new Proxy(sum, handler)
+
 export default {
   components: {
     TestComponent: {
@@ -79,7 +92,8 @@ export default {
       j: new Map([[1, 2], [3, 4], [5, new Map([[6, 7]])], [8, new Set([1, 2, 3, 4, new Set([5, 6, 7, 8]), new Map([[1, 2], [3, 4], [5, new Map([[6, 7]])]])])]]),
       html: '<b>Bold</b> <i>Italic</i>',
       htmlReg: /<b>hey<\/b>/i,
-      'html <b>key</b>': (h, t, m, l) => {}
+      'html <b>key</b>': (h, t, m, l) => {},
+      proxy1
     }
   },
   computed: {

--- a/src/util.js
+++ b/src/util.js
@@ -245,7 +245,12 @@ export function getCustomComponentDefinitionDetails (def) {
 }
 
 export function getCustomFunctionDetails (func) {
-  const string = Function.prototype.toString.call(func) || ''
+  const string = ''
+  try {
+    string = Function.prototype.toString.call(func)
+  } catch (e) {
+    // Func is probably a Proxy, which can break Function.prototype.toString()
+  }
   const matches = string.match(/\(.*\)/)
   const args = matches ? matches[0] : '(?)'
   return {

--- a/src/util.js
+++ b/src/util.js
@@ -245,7 +245,7 @@ export function getCustomComponentDefinitionDetails (def) {
 }
 
 export function getCustomFunctionDetails (func) {
-  const string = ''
+  let string = ''
   try {
     string = Function.prototype.toString.call(func)
   } catch (e) {


### PR DESCRIPTION
Related to #568

Sometimes a Function Proxy gets inspected by `getCustomFunctionDetails()`, which breaks because `Function.prototype.toString` doesn't always work with Proxy objects.

This patch simply catches the `TypeError` and allows `vue-devtools` to continue rendering the Component details even if it contains funky Function Proxies.  Currently if this occurs the Component detail view doesn't show, which leaves developers stuck tracking down the cause of the issue without the help of `vue-devtools`.  This patch will at least allow the Component details to render, but the Function Proxy in question will not show argument details.

There might be a way to continue rendering the arguments for certain Function Proxies but I don't think it would be completely general.