### PR TITLE
Fix loosing <Root> #269

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -163,7 +163,7 @@ function scan () {
         if (typeof instance.__VUE_DEVTOOLS_ROOT_UID__ === 'undefined') {
           instance.__VUE_DEVTOOLS_ROOT_UID__ = ++rootUID
         }
-        rootInstances.push(instance)
+        rootInstances.push(instance.$root)
       }
 
       return true


### PR DESCRIPTION
We got a same issue to #269 . I don't know the real reason, but I believe this patch will fix it.

BTW, When I inspect the code, I found something, may be useful for finding the real reason @yyx990803 :

In the backend.js, when the detected `rootInstance`  is a `VueComponent`, we'll loose the `<Root>`