### PR TITLE
Duplicate removal  rootInstances

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -163,8 +163,9 @@ function scan () {
         if (typeof instance.__VUE_DEVTOOLS_ROOT_UID__ === 'undefined') {
           instance.__VUE_DEVTOOLS_ROOT_UID__ = ++rootUID
         }
-        if( rootInstances.indexOf(instance.$root) == -1 )
-        rootInstances.push(instance.$root)
+        if(rootInstances.indexOf(instance.$root) == -1) {
+           rootInstances.push(instance.$root)
+        }
       }
 
       return true

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -165,6 +165,8 @@ function scan () {
         }
         if (rootInstances.indexOf(instance.$root) === -1) {
           rootInstances.push(instance.$root)
+        } else {
+          rootInstances.push(instance)
         }
       }
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -163,8 +163,8 @@ function scan () {
         if (typeof instance.__VUE_DEVTOOLS_ROOT_UID__ === 'undefined') {
           instance.__VUE_DEVTOOLS_ROOT_UID__ = ++rootUID
         }
-        if(rootInstances.indexOf(instance.$root) == -1) {
-           rootInstances.push(instance.$root)
+        if (rootInstances.indexOf(instance.$root) === -1) {
+          rootInstances.push(instance.$root)
         }
       }
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -163,6 +163,7 @@ function scan () {
         if (typeof instance.__VUE_DEVTOOLS_ROOT_UID__ === 'undefined') {
           instance.__VUE_DEVTOOLS_ROOT_UID__ = ++rootUID
         }
+        if( rootInstances.indexOf(instance.$root) == -1 )
         rootInstances.push(instance.$root)
       }
 


### PR DESCRIPTION
Just as  [React Protals](https://reactjs.org/docs/portals.html) ,a DOM node that exists outside the DOM hierarchy of the parent component may be the same rootInstance    
eg.  
      [ iview      Modal/Poptip/Dropdown/...     "transfer"    props  ](https://www.iviewui.com/components/dropdown-en#API)   
       True  to   “ Whether   to append the layer in body ”   ,      Multi   duplicate  root instances   appear  in  vue-devtools . #645 

I think the better solution is if the same root node displays the component node, and different root nodes show another root node.