### PR TITLE
Prevent chrome devtools from opening the print modal

### DIFF
--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -84,6 +84,7 @@ export default {
               this.switchTab('events')
               return false
             } else if (key === 'p' || code === 'KeyP') {
+              // Prevent chrome devtools from opening the print modal
               return false
             }
         }

--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -83,6 +83,8 @@ export default {
             } else if (code === 'Digit3') {
               this.switchTab('events')
               return false
+            } else if (key === 'p' || code === 'KeyP') {
+              return false
             }
         }
       }


### PR DESCRIPTION
Fixes #667 

It's easy as that 😄 
I can image this is not desirable code, though, since it mixes functional code with a platform-specific quirk.

Any ideas?