### PR TITLE
Fix custom function details parsing

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -248,18 +248,22 @@ export function getCustomComponentDefinitionDetails (def) {
 
 export function getCustomFunctionDetails (func) {
   let string = ''
+  let matches = null
   try {
     string = Function.prototype.toString.call(func)
+    matches = String.prototype.match.call(string, /\([\s\S]*?\)/)
   } catch (e) {
     // Func is probably a Proxy, which can break Function.prototype.toString()
   }
-  const matches = string.match(/\([\s\S]*?\)/)
   // Trim any excess whitespace from the argument string
-  const args = matches ? `(${matches[0].substr(1, matches[0].length - 2).split(',').map(a => a.trim()).join(', ')})` : '(?)'
+  const match = matches && matches[0]
+  const args = typeof match === 'string'
+    ? `(${match.substr(1, match.length - 2).split(',').map(a => a.trim()).join(', ')})` : '(?)'
+  const name = typeof func.name === 'string' ? func.name : ''
   return {
     _custom: {
       type: 'function',
-      display: `<span>ƒ</span> ${escape(func.name)}${args}`
+      display: `<span>ƒ</span> ${escape(name)}${args}`
     }
   }
 }


### PR DESCRIPTION
Fix #708 

- When `func` argument is a Proxy function than `toString` can return function.
- Add additional check to `matches`
- Add check that `func.name` is a string. With proxy example in the issue description `func.name` will throw an error