### PR TITLE
Only open file if it's a full path

### DIFF
--- a/src/devtools/views/components/ComponentInspector.vue
+++ b/src/devtools/views/components/ComponentInspector.vue
@@ -26,8 +26,8 @@
         <span>Inspect DOM</span>
       </a>
       <a
-        v-if="target.file"
-        v-tooltip="target.file && $t('ComponentInspector.openInEditor.tooltip', { file: target.file })"
+        v-if="fileIsPath"
+        v-tooltip="$t('ComponentInspector.openInEditor.tooltip', { file: target.file })"
         class="button"
         @click="openInEditor"
       >
@@ -100,6 +100,12 @@ export default {
           [el.key]: el.value
         }, this.filter)
       })), 'type')
+    },
+
+    // Checks if the file is actually a path (e.g. '/path/to/file.vue'), or
+    // only the basename of a pre-compiled 3rd-party component (e.g. 'file.vue')
+    fileIsPath () {
+      return this.target.file && /[/\\]/.test(this.target.file)
     }
   },
 


### PR DESCRIPTION
Precompiled 3rd party components still need to define a `name` on components, because the `__file` property is not currently added in production. For privacy and practical reasons, we never want to add the full path to `__file` in production, but we want to start adding setting the file's basename in `vue-loader` and `rollup-plugin-vue`.

For this to work though, we'll want to start checking whether `__file` is a path here and only allow it to be opened if it is.