### PR TITLE
fix: nw.js splitPanes scrolling

### DIFF
--- a/src/devtools/App.vue
+++ b/src/devtools/App.vue
@@ -374,6 +374,8 @@ export default {
   padding-bottom 0 !important
 
 .container
+  height: calc(100% - 60px)
+  position relative
   overflow hidden
   flex 1
 

--- a/src/devtools/components/SplitPane.vue
+++ b/src/devtools/components/SplitPane.vue
@@ -123,6 +123,7 @@ export default {
 .left,
 .right
   position relative
+  height 100%
 
 .horizontal
   .bottom


### PR DESCRIPTION
There are no possibility to scroll panes when using devtools as extension of nw.js environment. These changes fix this problem.