### PR TITLE
fix routing tab header position

### DIFF
--- a/src/devtools/components/GroupDropdown.vue
+++ b/src/devtools/components/GroupDropdown.vue
@@ -95,7 +95,7 @@ export default {
     display flex
     align-items center
     padding 0 14px
-    height 48px
+    height 100%
     cursor pointer
   & /deep/ svg
     fill #2c3e50

--- a/src/devtools/components/GroupDropdown.vue
+++ b/src/devtools/components/GroupDropdown.vue
@@ -117,7 +117,7 @@ export default {
   position absolute
   background white
   left 0
-  top 48px
+  top 100%
   width 100%
   box-shadow 0 3px 6px rgba(0,0,0,0.15)
   border-bottom-left-radius 3px


### PR DESCRIPTION
Routing Tab Header doesnt adjust height on smaller screens

![routingtab](https://user-images.githubusercontent.com/12878391/45390628-eb0a5680-b5ed-11e8-881f-70ea9967568b.png)
