### PR TITLE
Include Milliseconds as a Date-time Format Preference

### DIFF
--- a/src/devtools/components/GroupDropdown.vue
+++ b/src/devtools/components/GroupDropdown.vue
@@ -95,7 +95,7 @@ export default {
     display flex
     align-items center
     padding 0 14px
-    height 48px
+    height 100%
     cursor pointer
   & /deep/ svg
     fill #2c3e50

--- a/src/devtools/components/GroupDropdown.vue
+++ b/src/devtools/components/GroupDropdown.vue
@@ -117,7 +117,7 @@ export default {
   position absolute
   background white
   left 0
-  top 48px
+  top 100%
   width 100%
   box-shadow 0 3px 6px rgba(0,0,0,0.15)
   border-bottom-left-radius 3px

--- a/src/devtools/filters.js
+++ b/src/devtools/filters.js
@@ -1,3 +1,6 @@
-export function formatTime (timestamp) {
-  return (new Date(timestamp)).toString().match(/\d\d:\d\d:\d\d/)[0]
+export function formatTime (timestamp, format) {
+  const date = new Date(timestamp)
+  return `${date.toString().match(/\d\d:\d\d:\d\d/)[0]}${
+    format === 'ms' ? '.' + date.getMilliseconds() : ''
+  }`
 }

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -10,6 +10,7 @@ import SharedData, { init as initSharedData, destroy as destroySharedData } from
 import storage from './storage'
 import VuexResolve from './views/vuex/resolve'
 
+//register filters
 for (const key in filters) {
   Vue.filter(key, filters[key])
 }
@@ -181,11 +182,6 @@ function initApp (shell) {
 
     bridge.on('routes:changed', payload => {
       store.commit('routes/CHANGED', parse(payload))
-    })
-
-    // register filters
-    Vue.filter('formatTime', function (timestamp) {
-      return (new Date(timestamp)).toString().match(/\d\d:\d\d:\d\d/)[0]
     })
 
     bridge.on('events:reset', () => {

--- a/src/devtools/style/global.styl
+++ b/src/devtools/style/global.styl
@@ -71,6 +71,16 @@ $arrow-color = $vue-ui-color-dark
     border-bottom 4px solid transparent
     border-right 6px solid $arrow-color
 
+.vue-ui-dark-mode .arrow
+  &.up
+    border-bottom 6px solid $white
+  &.down
+    border-top 6px solid $white
+  &.right
+    border-left 6px solid $white
+  &.left
+    border-right 6px solid $white
+
 .notice
   display flex
   align-items center

--- a/src/devtools/views/events/EventsHistory.vue
+++ b/src/devtools/views/events/EventsHistory.vue
@@ -68,7 +68,7 @@
             <span class="component-name">{{ displayComponentName(event.instanceName) }}</span>
             <span>&gt;</span>
           </span>
-          <span class="time">{{ event.timestamp | formatTime }}</span>
+          <span class="time">{{ event.timestamp | formatTime($shared.timeFormat)}}</span>
         </div>
       </template>
     </recycle-list>

--- a/src/devtools/views/perf/FramerateGraph.vue
+++ b/src/devtools/views/perf/FramerateGraph.vue
@@ -69,7 +69,6 @@
 import { mapState, mapGetters } from 'vuex'
 import * as d3 from 'd3'
 import { FPS_MARKERS_PRECISION } from './module'
-import { formatTime } from 'filters'
 
 import SplitPane from 'components/SplitPane.vue'
 import FramerateMarkerInspector from './FramerateMarkerInspector.vue'
@@ -167,8 +166,8 @@ export default {
     getBarTootip (metric) {
       return `
       <div>${metric.value} frames per second</div>
-      <div style="color:#999;">${formatTime(metric.time)}</div>
-      `
+      <div style="color:#999;">${this.$options.filters.formatTime(metric.time, this.$shared.timeFormat)}</div>
+`
     },
 
     getMarkerStyle (marker) {

--- a/src/devtools/views/perf/FramerateMarkerInspector.vue
+++ b/src/devtools/views/perf/FramerateMarkerInspector.vue
@@ -32,7 +32,7 @@
             @click="selectedEntry = entry"
           >
             <div class="label">{{ entry.label }}</div>
-            <div class="time">{{ entry.timestamp | formatTime }}</div>
+            <div class="time">{{ entry.timestamp | formatTime($shared.timeFormat) }}</div>
           </div>
         </div>
       </div>

--- a/src/devtools/views/router/RouterHistory.vue
+++ b/src/devtools/views/router/RouterHistory.vue
@@ -57,10 +57,10 @@
           @click="inspect(filteredRoutes.indexOf(route))"
         >
           <span class="route-name">{{ route.to.path }}</span>
-          <span class="time">{{ route.timestamp | formatTime }}</span>
+          <span class="time">{{ route.timestamp | formatTime($shared.timeFormat) }}</span>
           <span
-            v-if="route.to.redirectedFrom"
-            class="label redirect"
+          v-if="route.to.redirectedFrom"
+          class="label redirect"
           >
             redirect
           </span>

--- a/src/devtools/views/settings/GlobalPreferences.vue
+++ b/src/devtools/views/settings/GlobalPreferences.vue
@@ -58,5 +58,21 @@
         />
       </VueGroup>
     </VueFormField>
+    <VueFormField title="Date/Time Format">
+      <VueGroup
+        :value="$shared.timeFormat"
+        class="extend"
+        @input="$shared.timeFormat = $event"
+      >
+        <VueGroupButton
+          value="default"
+          label="Default"
+        />
+        <VueGroupButton
+          value="ms"
+          label="Include ms"
+        />
+      </VueGroup>
+    </VueFormField>
   </div>
 </template>

--- a/src/devtools/views/vuex/VuexHistory.vue
+++ b/src/devtools/views/vuex/VuexHistory.vue
@@ -80,7 +80,7 @@
             </a>
           </span>
           <span class="time">
-            {{ lastCommit | formatTime }}
+            {{ lastCommit | formatTime($shared.timeFormat) }}
           </span>
           <span
             v-if="activeIndex === -1"
@@ -137,10 +137,10 @@
             </a>
           </span>
           <span
-            v-tooltip="entry.timestamp"
-            class="time"
+          v-tooltip="entry.timestamp"
+          class="time"
           >
-            {{ entry.timestamp | formatTime }}
+            {{ entry.timestamp | formatTime($shared.timeFormat) }}
           </span>
           <span
             v-if="isActive(index, entry)"

--- a/src/shared-data.js
+++ b/src/shared-data.js
@@ -4,6 +4,7 @@ const internalSharedData = {
   classifyComponents: true,
   theme: 'auto',
   displayDensity: 'low',
+  timeFormat: 'default',
   recordVuex: true,
   cacheVuexSnapshotsEvery: 50,
   cacheVuexSnapshotsLimit: 10,
@@ -15,7 +16,8 @@ const persisted = [
   'classifyComponents',
   'theme',
   'displayDensity',
-  'recordVuex'
+  'recordVuex',
+  'timeFormat'
 ]
 
 // ---- INTERNALS ---- //


### PR DESCRIPTION
Closes issue #777 by adding a Global Preference for users to include milliseconds in timestamps throughout devtools. Also removes formatTime filter from being registered twice.