### PR TITLE
Adjusts styling of tooltip icons in dark-mode

### DIFF
--- a/src/devtools/style/global.styl
+++ b/src/devtools/style/global.styl
@@ -182,3 +182,6 @@ $arrow-color = $vue-ui-color-dark
         fill #444
         .vue-ui-dark-mode &
           fill #666
+
+.vue-ui-dark-mode .tooltip .vue-ui-icon svg
+  fill #666


### PR DESCRIPTION
In dark mode, mouse icons were the same color as background of tooltip:

![screen shot 2018-09-24 at 7 23 43 pm](https://user-images.githubusercontent.com/12878391/45984506-67aa2580-c02f-11e8-95a4-909c94f4c91a.png)
