### PR TITLE
Add separate devtools-client package.

### DIFF
--- a/shells/client/.npmignore
+++ b/shells/client/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+src

--- a/shells/client/index.js
+++ b/shells/client/index.js
@@ -1,0 +1,24 @@
+require('./build/hook.js')
+
+const target = typeof window !== 'undefined'
+  ? window
+  : typeof global !== 'undefined'
+    ? global
+    : {}
+
+module.exports = {
+  connect: function (host, port, { io, showToast, app } = {}) {
+    target.__VUE_DEVTOOLS_HOST__ = host
+    target.__VUE_DEVTOOLS_PORT__ = port
+    if (io) target.__VUE_DEVTOOLS_SOCKET__ = io
+    if (showToast) target.__VUE_DEVTOOLS_TOAST__ = showToast
+    if (app) target.__VUE_ROOT_INSTANCES__ = Array.isArray(app) ? app : [app]
+
+    require('./build/backend.js')
+  },
+  init: (Vue) => {
+    const tools = target.__VUE_DEVTOOLS_GLOBAL_HOOK__
+
+    tools.emit('init', Vue)
+  }
+}

--- a/shells/client/package.json
+++ b/shells/client/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "@vue/devtools",
+  "name": "@vue/devtools-client",
   "version": "5.0.0-beta.3",
-  "description": "StandAlone vue-devtools",
+  "description": "Client for connecting to @vue/devtools",
   "repository": {
     "url": "https://github.com/vuejs/vue-devtools.git",
     "type": "git"
   },
-  "bin": {
-    "vue-devtools": "./bin.js"
-  },
   "main": "index.js",
   "scripts": {
-    "start": "node bin.js",
     "dev": "webpack --watch --hide-modules",
     "build": "webpack",
     "prepublishOnly": "npm run build"
@@ -19,12 +15,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "cross-spawn": "^5.1.0",
-    "electron": "1.7.11",
-    "express": "^4.16.2",
-    "ip": "^1.1.5",
-    "socket.io": "^2.0.4",
-    "@vue/devtools-client": "^5.0.0-beta.3"
+    "socket.io": "^2.0.4"
   },
   "devDependencies": {
     "webpack": "^4.19.0",

--- a/shells/client/src/backend.js
+++ b/shells/client/src/backend.js
@@ -1,0 +1,58 @@
+import io from 'socket.io-client'
+import { initBackend } from 'src/backend'
+import Bridge from 'src/bridge'
+import { installToast } from 'src/backend/toast'
+import { target } from 'src/devtools/env'
+
+const host = target.__VUE_DEVTOOLS_HOST__ || 'http://localhost'
+const port = target.__VUE_DEVTOOLS_PORT__ !== undefined ? target.__VUE_DEVTOOLS_PORT__ : 8098
+const fullHost = port ? host + ':' + port : host
+const createSocket = target.__VUE_DEVTOOLS_SOCKET__ || io
+const socket = createSocket(fullHost)
+
+const connectedMessage = () => {
+  if (target.__VUE_DEVTOOLS_TOAST__) {
+    target.__VUE_DEVTOOLS_TOAST__('Remote Devtools Connected', 'normal')
+  }
+}
+
+const disconnectedMessage = () => {
+  if (target.__VUE_DEVTOOLS_TOAST__) {
+    target.__VUE_DEVTOOLS_TOAST__('Remote Devtools Disconnected', 'error')
+  }
+}
+
+socket.on('connect', () => {
+  connectedMessage()
+  initBackend(bridge)
+  socket.emit('vue-devtools-init')
+})
+
+// Global disconnect handler. Fires in two cases:
+// - after calling above socket.disconnect()
+// - once devtools is closed (that's why we need socket.disconnect() here too, to prevent further polling)
+socket.on('disconnect', (reason) => {
+  socket.disconnect()
+  disconnectedMessage()
+})
+
+// Disconnect socket once other client is connected
+socket.on('vue-devtools-disconnect-backend', () => {
+  socket.disconnect()
+})
+
+const bridge = new Bridge({
+  listen (fn) {
+    socket.on('vue-message', data => fn(data))
+  },
+  send (data) {
+    socket.emit('vue-message', data)
+  }
+})
+
+bridge.on('shutdown', () => {
+  socket.disconnect()
+  disconnectedMessage()
+})
+
+installToast(target)

--- a/shells/client/src/hook.js
+++ b/shells/client/src/hook.js
@@ -1,0 +1,4 @@
+import { installHook } from 'src/backend/hook'
+import { target } from 'src/devtools/env'
+
+installHook(target)

--- a/shells/client/webpack.config.js
+++ b/shells/client/webpack.config.js
@@ -1,0 +1,21 @@
+const createConfig = require('../createConfig')
+
+const target = {
+  chrome: 52,
+  firefox: 48,
+  safari: 9,
+  ie: 11
+}
+
+module.exports = createConfig({
+  entry: {
+    backend: './src/backend.js',
+    hook: './src/hook.js'
+  },
+  output: {
+    path: __dirname + '/build',
+    publicPath: '/build/',
+    filename: '[name].js'
+  },
+  devtool: '#cheap-module-source-map'
+}, target)

--- a/shells/electron/README.md
+++ b/shells/electron/README.md
@@ -44,16 +44,16 @@ To the `<head>` section of your app.
 
 #### Using dependency package
 
-Once you installed the package as project dependency, run:
+To make app builds smaller, the backend of this package is now available as `@vue/devtools-client`. It is now recommended to simply install this package as a **dev** dependency, and run the command below.
 ```bash
 ./node_modules/.bin/vue-devtools
 ```
 
 You can also use the global `vue-devtools` to start the app, but you might want to check if the local version matches the global one in this scenario to avoid any incompatibilities.
 
-Then import it directly in your app:
+In your app, run `npm install --save @vue/devtools-client`, and import it into your app:
 ```js
-import devtools from '@vue/devtools'
+import devtools from '@vue/devtools-client'
 // import Vue from 'vue'
 ```
 > Make sure you import devtools before Vue, otherwise it might not work as expected.
@@ -68,6 +68,8 @@ if (process.env.NODE_ENV === 'development') {
 **host** - is an optional argument that tells your application where devtools middleware server is running, if you debug you app on your computer you don't have to set this (the default is `http://localhost`), but if you want to debug your app on mobile devices, you might want to pass your local IP (e.g. `http://192.168.1.12`).
 
 **port** - is an optional argument that tells your application on what port devtools middleware server is running. If you use proxy server, you might want to set it to `null` so the port won't be added to connection URL.
+
+> For backwards compatibility, `@vue/devtools` declares `@vue/devtools-client` as a dependency, and `require('@vue/devtools')` behaves just like `require('@vue/devtools-client')`. However, it is recommended _not_ to package `@vue/devtools`, as that will include `electron`, `cross-spawn`, and other dependencies even if they aren't used in your app.
 
 #### FAQ:
 
@@ -113,7 +115,7 @@ For that you can also use ngrok, as it automatically proxies https requests to h
 Make sure that the page under `http://your-ip:8098` is returning a javascript coode on your device/simulator. If it doesn't - make sure to check your anti-virus or router/firewall settings. If it works - please follow the instructions, and connect to devtools using your IP. For example:
 
 ```js
-import devtools from '@vue/devtools'
+import devtools from '@vue/devtools-client'
 import Vue from 'vue'
 // ...
 

--- a/shells/electron/index.js
+++ b/shells/electron/index.js
@@ -1,24 +1,2 @@
-require('./build/hook.js')
-
-const target = typeof window !== 'undefined'
-  ? window
-  : typeof global !== 'undefined'
-    ? global
-    : {}
-
-module.exports = {
-  connect: function (host, port, { io, showToast, app } = {}) {
-    target.__VUE_DEVTOOLS_HOST__ = host
-    target.__VUE_DEVTOOLS_PORT__ = port
-    if (io) target.__VUE_DEVTOOLS_SOCKET__ = io
-    if (showToast) target.__VUE_DEVTOOLS_TOAST__ = showToast
-    if (app) target.__VUE_ROOT_INSTANCES__ = Array.isArray(app) ? app : [app]
-
-    require('./build/backend.js')
-  },
-  init: (Vue) => {
-    const tools = target.__VUE_DEVTOOLS_GLOBAL_HOOK__
-
-    tools.emit('init', Vue)
-  }
-}
+console.log('TIP: You can now require \'@vue/devtools-client\' instead');
+module.exports = require('@vue/devtools-client');


### PR DESCRIPTION
# Background

In experimenting with the recent addition of NativeScript support, I noticed one thing: electron was causing my builds to fail. But NativeScript apps don't even use electron, so I investigated why a desktop framework was being installed. A simple `npm list` command showed me what was happening. The `nativescript-vue-devtools` command depended on `@vue/devtools`, which depended on `electron`.

### Why is this a problem?

Having extra dependencies increases app size, and in some cases, can create issues that are hard to debug. There is no need to include electron in a mobile app.

### What does this pull request do?

I copied `shells/electron/index.js`, `shells/electron/src/hooks.js` and `shells/electron/backend.js` to a new folder: `shells/client`. I also copied the `package.json` over, and removed extra dependencies. I modified the package name to `@vue/devtools-client` to allow users to install this new backend package. I also modified `README.md` to discuss the new changes. I haven't added a README to the client shell folder yet.

### How do other people need to respond to this change?

App developers don't _need_ to do anything (see below). However, if they desire, developers currently using `@vue/devtools` as a runtime dependency (importing it using `require('@vue/devtools')`) may move `@vue/devtools` to dev dependencies, and instead import the new `@vue/devtools-client` package from the `shells/client` folder. This means that the only extra dependency being built with the app is socket.io.

### Backwards compatibility.

The `src/hooks.js` and `src/backend.js` files still exist in the electron shell, so the server behaves the same way. For backwards-compatibility with apps that use the "current" way of importing the dependency package, `@vue/devtools-client` has been declared as a dependency of the electron shell. `index.js` simply requires/exports `@vue/devtools-client`.

> If maintainers want to enforce version-likeness, feel free to revert `shells/electron/index.js` and remove the dependency.

### What's did I leave for maintainers to do

 - Add a README in `shells/client`
 - Decide whether to keep or revert `index.js` and `package.json` in `shells/electron` (see note above)
 - Whatever other changes you want to make