### PR TITLE
Updated readme for Remote devtools host

### DIFF
--- a/shells/electron/README.md
+++ b/shells/electron/README.md
@@ -31,7 +31,7 @@ Then add:
 Or if you want to debug your device remotely:
 ```html
 <script>
-  window.__VUE_DEVTOOLS_HOST__ = '<your-local-ip>' // default: localhost
+  window.__VUE_DEVTOOLS_HOST__ = 'http://<your-local-ip>' // default: http://localhost
   window.__VUE_DEVTOOLS_PORT__ = '<devtools-port>' // default: 8098
 </script>
 <script src="http://<your-local-ip>:8098"></script>


### PR DESCRIPTION
This addresses the documentation issue referenced in #648.

When debugging a remote application, the host name needs to be changed for vue-devtools.

https://github.com/vuejs/vue-devtools/blob/79de0488680abd226a67ab0ec4ebc114a920b24f/shells/electron/src/backend.js#L7

Shows that the default is set with a URI but the docs omit the URI.

This PR adds the URI to the docs.