### PR TITLE
#773: Fix payload on replaying mutation

### DIFF
--- a/cypress/integration/vuex-tab.js
+++ b/cypress/integration/vuex-tab.js
@@ -23,7 +23,7 @@ suite('vuex tab', () => {
 
   it('should filter state & getters', () => {
     cy.get('.right .search input').clear().type('cou')
-    cy.get('.data-field').should('have.length', 1)
+    cy.get('.data-field').should('have.length', 2)
     cy.get('.right .search input').clear().type('no value')
     cy.get('.data-field').should('have.length', 0)
     cy.get('.right .search input').clear()
@@ -58,6 +58,11 @@ suite('vuex tab', () => {
     cy.get('.vuex-state-inspector').then(el => {
       expect(el.text()).to.include('type:"INCREMENT"')
       expect(el.text()).to.include('count:2')
+    })
+    cy.get('.data-field .key').contains('lastCountPayload').click()
+    cy.get('.vuex-state-inspector').then(el => {
+      expect(el.text()).to.include('a: 1')
+      expect(el.text()).to.include('b: Object')
     })
     cy.get('#target').iframe().then(({ get }) => {
       get('#counter p').contains('1')

--- a/cypress/integration/vuex-tab.js
+++ b/cypress/integration/vuex-tab.js
@@ -61,8 +61,8 @@ suite('vuex tab', () => {
     })
     cy.get('.data-field .key').contains('lastCountPayload').click()
     cy.get('.vuex-state-inspector').then(el => {
-      expect(el.text()).to.include('a: 1')
-      expect(el.text()).to.include('b: Object')
+      expect(el.text()).to.include('a:1')
+      expect(el.text()).to.include('b:Object')
     })
     cy.get('#target').iframe().then(({ get }) => {
       get('#counter p').contains('1')

--- a/shells/dev/target/store.js
+++ b/shells/dev/target/store.js
@@ -7,6 +7,7 @@ export default new Vuex.Store({
   state: {
     inited: 0,
     count: 0,
+    lastCountPayload: null,
     date: new Date(),
     set: new Set(),
     map: new Map(),
@@ -23,8 +24,14 @@ export default new Vuex.Store({
   },
   mutations: {
     TEST_INIT: state => state.inited++,
-    INCREMENT: state => state.count++,
-    DECREMENT: state => state.count--,
+    INCREMENT: (state, payload) => {
+      state.count++
+      state.lastCountPayload = payload
+    },
+    DECREMENT: (state, payload) => {
+      state.count--
+      state.lastCountPayload = payload
+    },
     UPDATE_DATE: state => {
       state.date = new Date()
     },

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -146,7 +146,7 @@ export function initVuexBackend (hook, bridge) {
       // Replay mutations
       for (let i = snapshot.index + 1; i <= index; i++) {
         const mutation = mutations[i]
-        mutation.handlers.forEach(handler => handler(state, mutation.payload))
+        mutation.handlers.forEach(handler => handler(mutation.payload))
         if (i !== index && i % SharedData.cacheVuexSnapshotsEvery === 0) {
           takeSnapshot(i, state)
         }


### PR DESCRIPTION
closes #773 , closes #792, closes #802 
All handlers are `wrappedMutationHandler ` with only 1 argument - `payload`