### PR TITLE
don't execute getters on vuex init

### DIFF
--- a/src/backend/hook.js
+++ b/src/backend/hook.js
@@ -98,7 +98,10 @@ export function installHook (target) {
 
   hook.once('vuex:init', store => {
     hook.store = store
-    hook.initialStore = clone(store)
+    hook.initialStore = {
+      state: clone(store.state),
+      getters: store.getters
+    }
   })
 
   Object.defineProperty(target, '__VUE_DEVTOOLS_GLOBAL_HOOK__', {


### PR DESCRIPTION
Relating to issue #848 this change avoids cloning the getters when creating the initialStore. As a result the getters will no longer all be executed on init.