### PR TITLE
Bump to patched electron version

### DIFF
--- a/shells/electron/package.json
+++ b/shells/electron/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "cross-spawn": "^5.1.0",
-    "electron": "1.7.11",
+    "electron": "1.7.13",
     "express": "^4.16.2",
     "ip": "^1.1.5",
     "socket.io": "^2.0.4"

--- a/shells/electron/package.json
+++ b/shells/electron/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "cross-spawn": "^5.1.0",
-    "electron": "1.7.13",
+    "electron": "1.7.16",
     "express": "^4.16.2",
     "ip": "^1.1.5",
     "socket.io": "^2.0.4"


### PR DESCRIPTION
## Background

While installing native-script-vue, I was alerted to a critical security vulnerability and wanted to correct the issue. (https://nodesecurity.io/advisories/732)

### Why is this a problem?

Security is important. :-)

### What does this pull request do?

I bumped the minor version of electron to one that patches the vulnerability.

### How do other people need to respond to this change?

App developers don't need to do anything.

### Backwards compatibility.

By only bumping the minor version I hope there are none.

### What did I leave for maintainers to do?

Merge?

Addresses issue #804

Thanks to @tupperkion for their fantastic PR format.