### PR TITLE
Fix mutations replay

### DIFF
--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -146,7 +146,8 @@ export function initVuexBackend (hook, bridge) {
       // Replay mutations
       for (let i = snapshot.index + 1; i <= index; i++) {
         const mutation = mutations[i]
-        mutation.handlers.forEach(handler => handler(state, mutation.payload))
+        store._committing = true;
+        mutation.handlers.forEach(handler => handler(mutation.payload))
         if (i !== index && i % SharedData.cacheVuexSnapshotsEvery === 0) {
           takeSnapshot(i, state)
         }

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -147,7 +147,8 @@ export function initVuexBackend (hook, bridge) {
       for (let i = snapshot.index + 1; i <= index; i++) {
         const mutation = mutations[i]
         store._committing = true;
-        mutation.handlers.forEach(handler => handler(mutation.payload))
+        mutation.handlers.forEach(handler => handler(mutation.payload));
+        store._committing = false;
         if (i !== index && i % SharedData.cacheVuexSnapshotsEvery === 0) {
           takeSnapshot(i, state)
         }

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -146,9 +146,9 @@ export function initVuexBackend (hook, bridge) {
       // Replay mutations
       for (let i = snapshot.index + 1; i <= index; i++) {
         const mutation = mutations[i]
-        store._committing = true;
-        mutation.handlers.forEach(handler => handler(mutation.payload));
-        store._committing = false;
+        store._committing = true
+        mutation.handlers.forEach(handler => handler(mutation.payload))
+        store._committing = false
         if (i !== index && i % SharedData.cacheVuexSnapshotsEvery === 0) {
           takeSnapshot(i, state)
         }


### PR DESCRIPTION
Not sure if this fix makes sense, as I don't know the rest of the code, but creating a PR just in case.

Fixes #792. Also related to #757: The replay mutations makes Vue throw an error because it's not allowed to edit the store while not commiting. I added a line just before and after the mutations call to set `store._committing` to true, so it allows to commit.