### PR TITLE
Change REGEX_RE to allow use of / in filters

### DIFF
--- a/src/devtools/views/events/module.js
+++ b/src/devtools/views/events/module.js
@@ -4,7 +4,7 @@ import SharedData from 'src/shared-data'
 
 const ENABLED_KEY = 'EVENTS_ENABLED'
 const enabled = storage.get(ENABLED_KEY)
-const REGEX_RE = /^\/(.*?)\/(\w*)/
+const REGEX_RE = /^\/((?:(?:.*?)(?:\\\/)?)*?)\/(\w*)/
 
 const state = {
   enabled: enabled == null ? true : enabled,

--- a/src/devtools/views/vuex/module.js
+++ b/src/devtools/views/vuex/module.js
@@ -3,7 +3,7 @@ import * as actions from './actions'
 import { snapshotsCache } from './cache'
 import SharedData from 'src/shared-data'
 
-const REGEX_RE = /^\/(.*?)\/(\w*)/
+const REGEX_RE = /^\/((?:(?:.*?)(?:\\\/)?)*?)\/(\w*)/
 const ANY_RE = new RegExp('.*', 'i')
 
 const state = {


### PR DESCRIPTION
In mutation or event filtering, it is currently possible to filter using regexp, but not to use the `/` char in a regex.
This prevents to filter on namespaced mutation name, which is sad. My personnal example is that I wanted to filter out the mutation (core/logger/log) with the following regexp : `/^((?!core\/logger\/log).)*$/` and it didn't work. Filtering with `/^((?!logger).)*$/` did work as expected, but filters too much.

I checked the code in `src/devtools/views/vuex/module.js` an  `src/devtools/views/action/module.js`
The regexp `REGEX_RE = /^\/(.*?)\/(\w*)/` cuts the regexp at the first `/` encountered, making it impossible to use this char in a regexp, no matter how we try to escape it.

I see several ways to do solve it: 
- I'm not sure why the `.*` in REGEXP_RE is not greedy. removing the ? seems to work : `REGEX_RE = /^\/(.*)\/(\w*)/`
- Same with the absence of $ at the end. If we assume there only is a regexp in the field (I don't know vue-devtools enough to know it it's a reasonable assumption) : `REGEX_RE = /^\/(.*?)\/(\w*)$/`.
- Allow escaping it with \ as we would in javascript code. I belive the right regexp for this would be `REGEX_RE = /^\/((?:(?:.*?)(?:\\\/)?)*?)\/(\w*)/`

I implemented the last solution, which seems cleaner because closer to the initial design that I may not fully understand, and thus less likely to have side effects. It's also closer to the javascript syntax.

I'm not 100% sure of my regexp choice, but I tested it in what seemed to be representative cases (https://gist.github.com/Etiennef/2ef33b57fc7b63e730db050f8b905ce1)