### PR TITLE
Fix browser env mutation.handlers is undefined

### DIFF
--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -146,10 +146,10 @@ export function initVuexBackend (hook, bridge) {
       // Replay mutations
       for (let i = snapshot.index + 1; i <= index; i++) {
         const mutation = mutations[i]
-        if (mutation.handlers){
+        if (mutation.handlers) {
           mutation.handlers.forEach(handler => handler(mutation.payload))
         }
-        
+
         if (i !== index && i % SharedData.cacheVuexSnapshotsEvery === 0) {
           takeSnapshot(i, state)
         }

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -146,7 +146,10 @@ export function initVuexBackend (hook, bridge) {
       // Replay mutations
       for (let i = snapshot.index + 1; i <= index; i++) {
         const mutation = mutations[i]
-        mutation.handlers.forEach(handler => handler(mutation.payload))
+        if (mutation.handlers){
+          mutation.handlers.forEach(handler => handler(mutation.payload))
+        }
+        
         if (i !== index && i % SharedData.cacheVuexSnapshotsEvery === 0) {
           takeSnapshot(i, state)
         }


### PR DESCRIPTION
In the latest Firefox and Google browsers, state data tree will not load for error:[mutation.handlers is undefined], because mutation handler actually passes is null (store. _mutations is empty) while pushing the handlers value as an element to the base mutations array, just add robust check.