### PR TITLE
fix: error on edit data of component without properties in devtools (#882)

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -524,6 +524,10 @@ export function get (object, path) {
 }
 
 export function has (object, path, parent = false) {
+  if (typeof object === 'undefined') {
+    return false
+  }
+
   const sections = path.split('.')
   const size = !parent ? 1 : 2
   while (sections.length > size) {


### PR DESCRIPTION
Error was throwed on editing data in devtools only when component had not props
(#882)