### PR TITLE
fix(vuex): make sure flushStoreModules return array

### DIFF
--- a/src/backend/hook.js
+++ b/src/backend/hook.js
@@ -124,7 +124,7 @@ export function installHook (target) {
         store.registerModule = origRegister
         store.unregisterModule = origUnregister
       }
-      return hook.storeModules
+      return hook.storeModules || []
     }
   })
 


### PR DESCRIPTION
When the vuex store does not have `registerModule`, `flushStoreModules` will return `undefined` and make the following calls on hook.storeModules failed.

This happened in my early version of vuex apps.