### PR TITLE
#939 Refactor legacy VueX checking

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -128,10 +128,10 @@ function connect (Vue) {
 
   // vuex
   if (hook.store) {
-    initVuexBackend(hook, bridge, isLegacy)
+    initVuexBackend(hook, bridge, hook.store.commit === undefined)
   } else {
     hook.once('vuex:init', store => {
-      initVuexBackend(hook, bridge, isLegacy)
+      initVuexBackend(hook, bridge, store.commit === undefined)
     })
   }
 

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -442,13 +442,20 @@ class VuexBackend {
         } else if (mutation.handlers) {
           this.store._committing = true
           try {
-            const payload = mutation.payload
+            let payload = mutation.payload
+            if (!Array.isArray(payload)) {
+              payload = [payload]
+            }
+
             if (Array.isArray(mutation.handlers)) {
-              mutation.handlers.forEach(handler => handler(payload))
+              if (this.isLegacy) {
+                mutation.handlers.forEach(handler => handler(this.store.state, ...payload))
+              } else {
+                mutation.handlers.forEach(handler => handler(payload))
+              }
             } else {
-              if (this.isLegacy || SharedData.vuex1) {
-                // Vuex 1
-                mutation.handlers(this.store.state, payload)
+              if (this.isLegacy) {
+                mutation.handlers(this.store.state, ...payload)
               } else {
                 mutation.handlers(payload)
               }

--- a/src/backend/vuex.js
+++ b/src/backend/vuex.js
@@ -443,7 +443,8 @@ class VuexBackend {
           this.store._committing = true
           try {
             let payload = mutation.payload
-            if (!Array.isArray(payload)) {
+
+            if (this.isLegacy && !Array.isArray(payload)) {
               payload = [payload]
             }
 

--- a/src/devtools/views/settings/GlobalPreferences.vue
+++ b/src/devtools/views/settings/GlobalPreferences.vue
@@ -91,20 +91,5 @@
         May impact performance or cause crashes
       </template>
     </VueFormField>
-
-    <VueFormField
-      title="Vuex Legacy"
-    >
-      <VueSwitch v-model="$shared.vuex1">
-        Enable compatibility mode
-      </VueSwitch>
-      <template #subtitle>
-        <VueIcon
-          icon="warning"
-          class="medium"
-        />
-        If you use Vuex 1.x, enable this option
-      </template>
-    </VueFormField>
   </div>
 </template>

--- a/src/shared-data.js
+++ b/src/shared-data.js
@@ -13,8 +13,7 @@ const internalSharedData = {
   recordPerf: false,
   editableProps: false,
   logDetected: true,
-  vuexAutoload: false,
-  vuex1: false
+  vuexAutoload: false
 }
 
 const persisted = [
@@ -24,8 +23,7 @@ const persisted = [
   'recordVuex',
   'editableProps',
   'logDetected',
-  'vuexAutoload',
-  'vuex1'
+  'vuexAutoload'
 ]
 
 // ---- INTERNALS ---- //


### PR DESCRIPTION
Solves #939 

Contains 2 bugfixes.

So as I mentioned in the source issue, the config reading isn't worked for some reason, but instead of applying a separate option, my thought was to better to figure out the current VueX version. 

Since the `commit` not exist in the older (as you call `legacy`) versions my ide was that to check this function and the existence of it. 

There was an other compatibility issue as well which caused by how the payload was passed to the mutation handler on legacy mode. I've solved this with simply convert the payload to an array when it's a legacy mode. 
