### PR TITLE
fix: style issue on Settings Tab

### DIFF
--- a/src/devtools/views/settings/SettingsTab.vue
+++ b/src/devtools/views/settings/SettingsTab.vue
@@ -29,7 +29,7 @@ export default {
 
 <style lang="stylus" scoped>
 .settings
-  overflow auto
+  overflow auto !important
   >>> .preferences
     display flex
     flex-wrap wrap


### PR DESCRIPTION
I created issue #972 before.

Settings tab is not able to scroll down.

![스크린샷 2019-04-15 오전 9 57 49](https://user-images.githubusercontent.com/26682772/56102258-dbc5ff80-5f66-11e9-8166-89b7a38d8c1e.png)

Because even there is a CSS to make this tab as scrollable, 
cascading rule makes `overflow: auto` ignored.

So I checked if there is a same class name with `settings` and put `!important` to make high priority. 
