### PR TITLE
Fix required prop warning in settings tab

### DIFF
--- a/src/devtools/views/settings/GlobalPreferences.vue
+++ b/src/devtools/views/settings/GlobalPreferences.vue
@@ -77,7 +77,7 @@
       </VueSwitch>
     </VueFormField>
 
-    <VueFormField>
+    <VueFormField title="New Vuex backend">
       <template #title>
         New Vuex backend
         <NewTag :version="1" />


### PR DESCRIPTION
This pr fixes required prop warning in "settings" tab

<img width="1143" alt="Screen Shot 2019-05-07 at 4 04 13 PM" src="https://user-images.githubusercontent.com/10040154/57278743-55728880-70e2-11e9-8764-5f83825ea83d.png">
