### PR TITLE
Feature/add "copy path" option in context menu

### DIFF
--- a/src/devtools/components/DataField.vue
+++ b/src/devtools/components/DataField.vue
@@ -140,6 +140,12 @@
               >
                 {{ $t('DataField.contextMenu.copyValue') }}
               </VueDropdownButton>
+              <VueDropdownButton
+                icon-left="flip_to_front"
+                @click="copyPathToClipboard"
+              >
+                {{ $t('DataField.contextMenu.copyRelativePath') }}
+              </VueDropdownButton>
             </div>
           </VueDropdown>
         </span>
@@ -464,6 +470,10 @@ export default {
   },
 
   methods: {
+    copyPathToClipboard () {
+      copyToClipboard(this.path)
+    },
+
     copyToClipboard () {
       copyToClipboard(this.field.value)
     },

--- a/src/devtools/locales/en.js
+++ b/src/devtools/locales/en.js
@@ -37,7 +37,8 @@ export default {
       }
     },
     contextMenu: {
-      copyValue: 'Copy Value'
+      copyValue: 'Copy Value',
+      copyRelativePath: 'Copy relative path'
     },
     quickEdit: {
       number: {


### PR DESCRIPTION
## Feature
This PR will add a new action in the context menu dropdown that copies selected key`s relative path.

![](https://i.gyazo.com/679497c7cd4612d8120c2dbcb3a95419.gif)

## Motivation
When working/debugging with Vue-devtools, I often see a key that I would like to interact with, either by using the `$vm0.theKeyIWantToInspect` in the console, or simply just to use in code. I previously had to manually type out the path I wanted. This felt painfully hard (because i'm a lazy dude..)

## Changes
I am not too familiar with the code structure of vue-devtools to  be honest. Therefore, I observed how the current "copy value" function worked and slightly modified it to copy the path instead of the value.