### PR TITLE
fix: fallback for store modules namespace map

### DIFF
--- a/packages/app-backend/src/vuex.js
+++ b/packages/app-backend/src/vuex.js
@@ -343,7 +343,7 @@ class VuexBackend {
     return stringify({
       state: this.store.state,
       getters: getCatchedGetters(this.store),
-      modules: Object.keys(this.store._modulesNamespaceMap)
+      modules: Object.keys(this.store._modulesNamespaceMap || {})
         .map(m => m.substr(0, m.length - 1))
         .sort()
     })


### PR DESCRIPTION
Since the old VueX store doesn't have namespaces the devtools failed to load because of that. So i've added a fallback for it