### PR TITLE
style popups

### DIFF
--- a/packages/shell-chrome/popups/disabled.html
+++ b/packages/shell-chrome/popups/disabled.html
@@ -1,6 +1,8 @@
 <meta charset="utf-8">
-<p style="width: 200px">
-  Vue.js is detected on this page.
+<link rel="stylesheet" type="text/css" href="./popup.css">
+
+<p>
+  <strong>Vue.js is detected on this page.</strong><br/>
   Devtools inspection is not available because it's in
   production mode or explicitly disabled by the author.
 </p>

--- a/packages/shell-chrome/popups/disabled.nuxt.html
+++ b/packages/shell-chrome/popups/disabled.nuxt.html
@@ -1,6 +1,8 @@
 <meta charset="utf-8">
-<p style="width: 200px">
-  Nuxt.js + Vue.js is detected on this page.
+<link rel="stylesheet" type="text/css" href="./popup.css">
+
+<p>
+  <strong>Nuxt.js + Vue.js is detected on this page.</strong><br/>
   Devtools inspection is not available because it's in
   production mode or explicitly disabled by the author.
 </p>

--- a/packages/shell-chrome/popups/enabled.html
+++ b/packages/shell-chrome/popups/enabled.html
@@ -1,5 +1,7 @@
 <meta charset="utf-8">
-<p style="width: 180px;">
-  Vue.js is detected on this page.
+<link rel="stylesheet" type="text/css" href="./popup.css">
+
+<p>
+  <strong>Vue.js is detected on this page.</strong><br/>
   Open DevTools and look for the Vue panel.
 </p>

--- a/packages/shell-chrome/popups/enabled.nuxt.html
+++ b/packages/shell-chrome/popups/enabled.nuxt.html
@@ -1,5 +1,7 @@
 <meta charset="utf-8">
-<p style="width: 180px;">
-  Nuxt.js + Vue.js is detected on this page.
+<link rel="stylesheet" type="text/css" href="./popup.css">
+
+<p>
+  <strong>Nuxt.js + Vue.js is detected on this page.</strong><br/>
   Open DevTools and look for the Vue panel.
 </p>

--- a/packages/shell-chrome/popups/not-found.html
+++ b/packages/shell-chrome/popups/not-found.html
@@ -1,4 +1,6 @@
 <meta charset="utf-8">
-<p style="white-space: nowrap">
-  Vue.js not detected
+<link rel="stylesheet" type="text/css" href="./popup.css">
+
+<p class="short-paragraph">
+  <strong>Vue.js not detected</strong>
 </p>

--- a/packages/shell-chrome/popups/popup.css
+++ b/packages/shell-chrome/popups/popup.css
@@ -1,0 +1,23 @@
+body {
+  font-family: Roboto, Avenir, Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  padding: 10px 12px 12px 12px;
+  color: #2c3e50;
+}
+
+body,
+p {
+  margin: 0;
+}
+
+p {
+  min-width: 200px;
+  max-width: 300px;
+}
+
+.short-paragraph {
+  min-width: initial;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Fixes: #1014

This PR styles all popups to be more consistent with the rest of the devtools.
Using the same fonts and colors if available. Also tweaks the spacing so the text doesn't appear to be off center anymore.

<img width="238" alt="Bildschirmfoto 2019-10-29 um 10 07 58" src="https://user-images.githubusercontent.com/7128716/67752857-0cb5df80-fa34-11e9-8def-b242fae7ff4b.png">

<img width="238" alt="Bildschirmfoto 2019-10-29 um 10 09 11" src="https://user-images.githubusercontent.com/7128716/67752928-3111bc00-fa34-11e9-954e-7a72c508ddf0.png">