### PR TITLE
Fix ActionHeader icons display for small width

### DIFF
--- a/packages/app-frontend/src/components/ActionHeader.vue
+++ b/packages/app-frontend/src/components/ActionHeader.vue
@@ -36,6 +36,7 @@
 
 .vue-ui-icon
   width 16px
+  min-width @width
   height @width
   margin-right 0
   @media (min-width: $wide)


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3998654/71641685-9db16d00-2ca8-11ea-95a2-837f334333ef.png)
After:
![image](https://user-images.githubusercontent.com/3998654/71641690-b4f05a80-2ca8-11ea-906a-ebbcd11b7b6c.png)
