### PR TITLE
Vue3: Fixes issue with __VUE_DEVTOOLS_APP_RECORD being undefined

### DIFF
--- a/packages/app-backend-vue3/src/components/util.ts
+++ b/packages/app-backend-vue3/src/components/util.ts
@@ -8,7 +8,7 @@ export function isBeingDestroyed (instance) {
 
 export function getAppRecord (instance) {
   if (instance.root) {
-    return instance.appContext.__app.__VUE_DEVTOOLS_APP_RECORD__
+    return instance.appContext.app.__VUE_DEVTOOLS_APP_RECORD__
   }
 }
 


### PR DESCRIPTION
Vue3: Fixes issue with `__VUE_DEVTOOLS_APP_RECORD` being accessed through `.__app` instead of `.app` as reported in https://github.com/vuejs/vue-devtools/issues/1246.