### PR TITLE
fix: defensive checking in reviver function #1186

### DIFF
--- a/packages/shared-utils/src/util.js
+++ b/packages/shared-utils/src/util.js
@@ -372,6 +372,9 @@ function reviver (key, val) {
     return Symbol.for(string)
   } else if (specialTypeRE.test(val)) {
     const [, type, string] = specialTypeRE.exec(val)
+    if (!window[type]){
+      return undefined
+    }
     return new window[type](string)
   } else {
     return val


### PR DESCRIPTION
Fix Vuex stuck on loading state when VNodes committed from a slot
Issue #1186

![image](https://user-images.githubusercontent.com/30585557/92370674-cdacec00-f124-11ea-8bc2-059218a8c7cc.png)
