### PR TITLE
fix(timeline): error when no appRecord found

### DIFF
--- a/packages/app-backend-core/src/timeline.ts
+++ b/packages/app-backend-core/src/timeline.ts
@@ -123,7 +123,7 @@ export function addTimelineEvent (options: TimelineEventOptions, app: App, ctx: 
 
   if (!isAllApps && app) {
     const appRecord = getAppRecord(app, ctx)
-    registerTimelineEvent(eventData, appRecord, ctx)
+    appRecord && registerTimelineEvent(eventData, appRecord, ctx)
   } else {
     ctx.appRecords.forEach(appRecord => registerTimelineEvent(eventData, appRecord, ctx))
   }


### PR DESCRIPTION
`appRecord` is `undefined` in some weird cases, like the one in the reproduction link in the issue: intlify/vue-i18n-next#293. I guess it's because the devtools is not aware of the app yet? I'm not sure.

This fixes intlify/vue-i18n-next#293. I reported it there because I didn't know how to reproduce it without vue-i18n, and at the time I wasn't sure if it was a vue-devtools bug or vue-i18n bug.