### PR TITLE
fix(vuex): error when register same module

### DIFF
--- a/packages/app-backend/src/vuex.js
+++ b/packages/app-backend/src/vuex.js
@@ -515,6 +515,7 @@ class VuexBackend {
     const result = this.stringifyStore()
 
     // Restore user state
+    tempAddedModules = [...new Set(tempAddedModules)];
     tempAddedModules.sort((a, b) => b.length - a.length).forEach(m => {
       this.origUnregisterModule(m.split('/'))
       if (!isProd) console.log('after replay unregister', m)

--- a/packages/app-backend/src/vuex.js
+++ b/packages/app-backend/src/vuex.js
@@ -515,7 +515,7 @@ class VuexBackend {
     const result = this.stringifyStore()
 
     // Restore user state
-    tempAddedModules = [...new Set(tempAddedModules)];
+    tempAddedModules = [...new Set(tempAddedModules)]
     tempAddedModules.sort((a, b) => b.length - a.length).forEach(m => {
       this.origUnregisterModule(m.split('/'))
       if (!isProd) console.log('after replay unregister', m)


### PR DESCRIPTION
My web application will register the same vuex modules multiple times with `preserveState: true`.
When vue-devtools change tab to vuex tab and load state, the error will happen.

![image](https://user-images.githubusercontent.com/25414733/104707155-030eb980-5757-11eb-9466-201946f82ba8.png)

![image](https://user-images.githubusercontent.com/25414733/104707136-fb4f1500-5756-11eb-8129-8df499c5b5ed.png)
