### PR TITLE
missing argument for `Object.keys`

### DIFF
--- a/packages/shell-chrome/src/devtools-background.js
+++ b/packages/shell-chrome/src/devtools-background.js
@@ -119,7 +119,7 @@ const toastMessages = {
 }
 
 function toast (id) {
-  if (!Object.keys().includes(id)) return
+  if (!Object.keys(toastMessages).includes(id)) return
 
   const { message, type } = toastMessages[id]
 


### PR DESCRIPTION
Recent fix fa17699aba2bd9c76dd86d63143b9a28d1d3b05f has a missing argument for `Object.Keys()`.