### PR TITLE
Fix callHandlers is not a function

### DIFF
--- a/packages/app-backend-api/src/api.ts
+++ b/packages/app-backend-api/src/api.ts
@@ -36,8 +36,8 @@ export class DevtoolsApi {
 
   async callHook<T extends Hooks> (eventType: T, payload: HookPayloads[T], ctx: BackendContext = this.ctx) {
     payload = await backendOn.callHandlers(eventType, payload, ctx)
-    for (const k in pluginOn) {
-      payload = await pluginOn[k].callHandlers(eventType, payload, ctx)
+    for (const plugin of pluginOn) {
+      payload = await plugin.callHandlers(eventType, payload, ctx)
     }
     return payload
   }


### PR DESCRIPTION
#1422
Usage of `in` iterate on custom prototype methods. `of` should fix it.
close #1422 