### PR TITLE
fix(vue2): handling un-namespaced vuex module

### DIFF
--- a/packages/app-backend-vue2/src/plugin.ts
+++ b/packages/app-backend-vue2/src/plugin.ts
@@ -346,7 +346,7 @@ function extractNameFromPath (path: string) {
 }
 
 function formatStoreForInspectorState (module, getters, path): CustomInspectorState {
-  getters = path === 'root' ? getters : getters[path]
+  getters = !module.namespaced || path === 'root' ? module.context.getters : getters[path]
   const gettersKeys = Object.keys(getters)
   const storeState: CustomInspectorState = {
     state: Object.keys(module.state).map((key) => ({


### PR DESCRIPTION
I found Vue Devtools 6 fails to handle Vuex modules without namespace (`namespaced = false`).
The `getters` of that kind of modules seems to be got from `module.context.getters`.

---
add details...

I fixed the part of `formatStoreForInspectorState` and it is called from following part.

https://github.com/vuejs/vue-devtools/blob/d5e0579b35a7c93869ddb839e3863219202ab0ec/packages/app-backend-vue2/src/plugin.ts#L101-L114

This means `getters` argument of `formatStoreForInspectorState` is `store._makeLocalGettersCache`, but `store._makeLocalGettersCache` doesn't look includes `root` modules' ones and **un** -namespaced moduels' ones but only includes namespaced modules' ones. 

So before my fixing, `TypeError: Cannot convert undefined or null to object` error occurs at line 350 since getters of un-namespaced modules are not contained by `getters[path]`.

https://github.com/vuejs/vue-devtools/blob/d5e0579b35a7c93869ddb839e3863219202ab0ec/packages/app-backend-vue2/src/plugin.ts#L348-L351